### PR TITLE
Use relative path for dbt docs now that we have a public github pages url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,8 +34,8 @@ nav:
   - dbt: dbt.md
   - Snowflake: snowflake.md
   - Writing Documentation: writing-documentation.md
-  - dbt Snowflake Project: /dbt_docs_snowflake/index.html
-  - dbt BigQuery Project: /dbt_docs_bigquery/index.html
+  - dbt Snowflake Project: dbt_docs_snowflake/index.html
+  - dbt BigQuery Project: dbt_docs_bigquery/index.html
   - Learning:
       - MDSA Glossary: learning/glossary.md
       - git: learning/git.md


### PR DESCRIPTION
These absolute paths were no longer correct once we changed the visibility of the repo from private to public. Changing them to relative paths fixes it.