### PR TITLE
Lock terraform provider versions to avoid issues on upgrade

### DIFF
--- a/docs/cloud-infrastructure.md
+++ b/docs/cloud-infrastructure.md
@@ -128,6 +128,17 @@ terraform apply
 
 This will output the changes to the infrastructure that will be made, and prompt you for confirmation.
 
+## Updating terraform dependencies
+
+Terraform deployments include a lockfile with hashes of installed packages.
+Because we have mixed development environments (i.e., Macs locally, Linux in CI),
+it is helpful to include both Mac and Linux builds of terraform packages in the lockfile.
+This needs to be done every time package versions are updated:
+
+```bash
+terraform init -upgrade  # Upgrade versions
+terraform providers lock -platform=linux_amd64 -platform=darwin_amd64  # include Mac and Linux binaries
+```
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/terraform/snowflake/environments/dev/.terraform.lock.hcl
+++ b/terraform/snowflake/environments/dev/.terraform.lock.hcl
@@ -2,18 +2,20 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/snowflake-labs/snowflake" {
-  version     = "0.61.0"
-  constraints = "~> 0.61"
+  version     = "0.69.0"
+  constraints = "~> 0.61, 0.69.0"
   hashes = [
-    "h1:+7wwZ5nQJCUUDEBF4dSysNtdyBYb92xDO8S1rqTH6QM=",
-    "h1:mN4MMG74G0GW0pBnudVIfzBEIBtCOci/DQNrHzWadek=",
-    "h1:mR7J21jMjTKKkmbpiHQJdtLt8hFDghsep+Y3alrtc78=",
-    "zh:0b4a2ce832a43d87dbaff693e80ee0c9e8bd158b6db40c02d131c3232297c45c",
-    "zh:3d06a98e51697b9dbf8be62145f06ffdc8a5d0fb7e78b8987e9ae619b555a88b",
-    "zh:5bcebd8019d94d2b7eb989a4b004eb6034ad3583093192a47ab7b181aacb9ff8",
-    "zh:6071e25b52ad1f30db5972be40c93b7b1df7df58365d25a5260c8724c7b18ce9",
-    "zh:8bc3677156ff7a6e9712febbbda9579c5838b21b70e94e53ea66f0c8027f54da",
-    "zh:d6b826d476959ac31ef41510f6ef2c56255a98b4e86a006dfbed2330670797c6",
+    "h1:0CSDES330nTqimmmNwQxxp24dDkRGYTrz46wjJDBG9M=",
+    "h1:S57eACfdn03/8yUFRcSA52BsBsuEIJ0KwP5jhdoKMuY=",
+    "h1:rB052GXnpNuUR9ZeGgiY8imkQqPWkI32PtiqWTORJXQ=",
+    "zh:05c38443ecce2a74568a182eb8a796db5d333846552d75c16b158f5034e824a3",
+    "zh:38b549a2e09b911709c85340222533cff9fde9c0de3e83cb906891822b340279",
+    "zh:3d4468d3be703c0545db94f6f1861ffd0f6e6e40cbdad6cf22506fcf368d33cd",
+    "zh:43ae1d8dd68545923ad460593b3f9c6d0a010b66c8ece7c62e4c2c716e3bb848",
+    "zh:4f4bb057e411138f876cc87b676269f23d62ffeafd4bbcf7d96521ee8abb2dff",
+    "zh:51c3f30ec1ede2c002d103e0dfeee187ef69be77c7a948355f6e5a5c505745f2",
+    "zh:74e7fd7d960a2e7e069941fb665e2873c4ced8cf84d5e1f8aded98ad9bb742c8",
+    "zh:97330c429ba7c17eec8ee325695bdc81093e1c70a275fd70ffeb00719ffc73ce",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/snowflake/environments/dev/main.tf
+++ b/terraform/snowflake/environments/dev/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.61"
+      version = "0.69"
     }
   }
   required_version = ">= 1.0"

--- a/terraform/snowflake/environments/prd/.terraform.lock.hcl
+++ b/terraform/snowflake/environments/prd/.terraform.lock.hcl
@@ -2,18 +2,20 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/snowflake-labs/snowflake" {
-  version     = "0.63.0"
-  constraints = "~> 0.61"
+  version     = "0.69.0"
+  constraints = "~> 0.61, 0.69.0"
   hashes = [
-    "h1:N2TUv8RXzaQXEbyaDR9qeiQdZzamsVO6SQ1I+GL7yHM=",
-    "h1:gwqcCFWn4awEQQwB9htJHPMZBzueIKjidkaOY+3ZbBk=",
-    "h1:pRLVLNfyn1zudpdSorafdfXMj8f67M59eM8akzYb1o8=",
-    "zh:37083f1c0dc61be68796f7cff0e8d6bb83777ae79cd7ad80d9a87cd2c1d7cff5",
-    "zh:46bd3ad88ac8fc4a24f5e84b79c4a204df8440ba2c9b62de2bf69a413b84f327",
-    "zh:7ed9f10b64ab3b021edb5c43c65d4c82e8ff42df0e4d288a10655be1725cbe45",
-    "zh:9f1b925ec78f22662300752c742ca62f054616a1a6d63e04e33525211c293b09",
-    "zh:b15412dd4b209e221513d04c17ee01cd6d88d6f77ac5d79abce2a56ebc094355",
-    "zh:b2e128adf7ffa1cab1d25e7b5d35345d89ac0f90b4149d0390a212ac1b16771a",
+    "h1:0CSDES330nTqimmmNwQxxp24dDkRGYTrz46wjJDBG9M=",
+    "h1:S57eACfdn03/8yUFRcSA52BsBsuEIJ0KwP5jhdoKMuY=",
+    "h1:rB052GXnpNuUR9ZeGgiY8imkQqPWkI32PtiqWTORJXQ=",
+    "zh:05c38443ecce2a74568a182eb8a796db5d333846552d75c16b158f5034e824a3",
+    "zh:38b549a2e09b911709c85340222533cff9fde9c0de3e83cb906891822b340279",
+    "zh:3d4468d3be703c0545db94f6f1861ffd0f6e6e40cbdad6cf22506fcf368d33cd",
+    "zh:43ae1d8dd68545923ad460593b3f9c6d0a010b66c8ece7c62e4c2c716e3bb848",
+    "zh:4f4bb057e411138f876cc87b676269f23d62ffeafd4bbcf7d96521ee8abb2dff",
+    "zh:51c3f30ec1ede2c002d103e0dfeee187ef69be77c7a948355f6e5a5c505745f2",
+    "zh:74e7fd7d960a2e7e069941fb665e2873c4ced8cf84d5e1f8aded98ad9bb742c8",
+    "zh:97330c429ba7c17eec8ee325695bdc81093e1c70a275fd70ffeb00719ffc73ce",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/snowflake/environments/prd/main.tf
+++ b/terraform/snowflake/environments/prd/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.61"
+      version = "0.69"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
Over in #172 I've lost a certain amount of trust in the Snowflake provider's stability from version to version. This locks the version down to the most recent stable release so it can't float up and cause unexpected changes.

No actual infrastructure changes, just being more strict with the versions
