### PR TITLE
Create public S3 bucket for building footprint artifacts.

### DIFF
--- a/docs/cloud-infrastructure.md
+++ b/docs/cloud-infrastructure.md
@@ -207,10 +207,14 @@ No modules.
 | [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/route_table) | resource |
 | [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/route_table_association) | resource |
+| [aws_s3_bucket.dof_demographics_public](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.dsa_project](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.mwaa](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.scratch](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_policy.dof_demographics_public_read_access](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.dof_demographics_public](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.mwaa](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_versioning.dof_demographics_public](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_bucket_versioning.dsa_project](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_bucket_versioning.mwaa](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/s3_bucket_versioning) | resource |
 | [aws_security_group.batch](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/security_group) | resource |
@@ -228,6 +232,7 @@ No modules.
 | [aws_iam_policy_document.aws_batch_service_policy](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.batch_submit_policy_document](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.default_ecr_policy_document](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.dof_demographics_public_read_access](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.mwaa](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_dsa_project_policy_document](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_list_all_my_buckets](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |

--- a/terraform/aws/modules/infra/s3.tf
+++ b/terraform/aws/modules/infra/s3.tf
@@ -69,6 +69,57 @@ resource "aws_s3_bucket_public_access_block" "mwaa" {
 }
 
 ##################################
+#     DSE MDSA Project Buckets   #
+##################################
+
+resource "aws_s3_bucket" "dof_demographics_public" {
+  bucket = "dof-demographics-${var.environment}-${var.region}-public"
+  tags = {
+    Owner   = "dof"
+    Project = "demographics"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "dof_demographics_public" {
+  bucket = aws_s3_bucket.dof_demographics_public.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+data "aws_iam_policy_document" "dof_demographics_public_read_access" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.dof_demographics_public.arn,
+      "${aws_s3_bucket.dof_demographics_public.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "dof_demographics_public_read_access" {
+  bucket = aws_s3_bucket.dof_demographics_public.id
+  policy = data.aws_iam_policy_document.dof_demographics_public_read_access.json
+}
+
+resource "aws_s3_bucket_public_access_block" "dof_demographics_public" {
+  bucket = aws_s3_bucket.dof_demographics_public.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+##################################
 #     AAE DSA Project Buckets    #
 ##################################
 


### PR DESCRIPTION
This follows the approach given [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteAccessPermissionsReqd.html). The files placed in this bucket will be publicly-downloadable, so clearly for public data only!

In support of #182