### PR TITLE
Set crs on footprints

### DIFF
--- a/jobs/geo/write_building_footprints.py
+++ b/jobs/geo/write_building_footprints.py
@@ -41,7 +41,8 @@ def write_building_footprints(conn):
 
         file_prefix = f"footprints_with_tiger_for_county_fips_{county}"
         gdf.to_parquet(f"{file_prefix}.parquet")
-        gdf.to_file(f"{file_prefix}.shp.zip")
+        # .shz suffix triggers GDAL to write zipped shapefile
+        gdf.to_file(f"{file_prefix}.shz")
 
         print(
             f"Loading {file_prefix}. This is number {index+1} out of {len(counties)} counties."
@@ -52,12 +53,14 @@ def write_building_footprints(conn):
             f"{file_prefix}.parquet",
             "s3://dof-demographics-dev-us-west-2-public/parquet/",
         )
+        # Esri doesn't like .shp.zip or .shz, so rename to just be .zip.
         s3.put(
-            f"{file_prefix}.shp.zip", "s3://dof-demographics-dev-us-west-2-public/shp/"
+            f"{file_prefix}.shz",
+            f"s3://dof-demographics-dev-us-west-2-public/shp/{file_prefix}.zip",
         )
 
         os.remove(f"{file_prefix}.parquet")
-        os.remove(f"{file_prefix}.shp.zip")
+        os.remove(f"{file_prefix}.shz")
 
 
 if __name__ == "__main__":

--- a/jobs/geo/write_building_footprints.py
+++ b/jobs/geo/write_building_footprints.py
@@ -9,7 +9,7 @@ def write_building_footprints(conn):
 
     import geopandas
     import s3fs
-    import shapely
+    import shapely.wkb
 
     sql_alter = """
     alter session set GEOGRAPHY_OUTPUT_FORMAT='WKB';
@@ -33,7 +33,8 @@ def write_building_footprints(conn):
         """
         df = conn.cursor().execute(sql_table).fetch_pandas_all()
         gdf = geopandas.GeoDataFrame(
-            df.assign(geometry=df.geometry.apply(shapely.wkb.loads))
+            df.assign(geometry=df.geometry.apply(shapely.wkb.loads)),
+            crs="EPSG:4326",
         )
 
         gdf = gdf[gdf.geometry.geom_type != "GeometryCollection"]


### PR DESCRIPTION
Some fixes for https://github.com/cagov/data-infrastructure/pull/182#issuecomment-1725901699

* Set the CRS on datasets before writing them to S3
* Ensure the zipped shapefiles just end in `.zip` rather than `.shp.zip`, which was causing some problems with Esri tooling.