### PR TITLE
Pin to python 3.10 for CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
       - uses: snok/install-poetry@v1
         with:
           virtualenvs-create: false


### PR DESCRIPTION
Some recent CI builds have been struggling with the brand new Python 3.12. This pins to 3.10 for the time being