### PR TITLE
Autosuspend logging warehouse after one second

### DIFF
--- a/terraform/snowflake/modules/elt/warehouses.tf
+++ b/terraform/snowflake/modules/elt/warehouses.tf
@@ -68,5 +68,5 @@ module "logging" {
   name         = "LOGGING_XS_${var.environment}"
   comment      = "Primary warehouse for logging. Logging tools like Sentinel should use this warehouse."
   size         = "X-SMALL"
-  auto_suspend = 5
+  auto_suspend = 1
 }


### PR DESCRIPTION
Autosuspend logging warehouse even more aggressively to reduce costs as it logs every two minutes.