### PR TITLE
Airflow maintenance and improvements

### DIFF
--- a/airflow/aws_cli.py
+++ b/airflow/aws_cli.py
@@ -1,0 +1,34 @@
+"""
+Python script to run airflow CLI commands in a MWAA environment.
+
+Adapted from sample code here:
+https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-cli-command-reference.html#airflow-cli-command-examples
+"""
+import base64
+import sys
+
+import boto3
+import requests
+
+mwaa_env_name = "dse-infra-dev-us-west-2-mwaa-environment"
+
+client = boto3.client("mwaa")
+
+mwaa_cli_token = client.create_cli_token(Name=mwaa_env_name)
+
+mwaa_auth_token = "Bearer " + mwaa_cli_token["CliToken"]
+mwaa_webserver_hostname = f"https://{mwaa_cli_token['WebServerHostname']}/aws_mwaa/cli"
+raw_data = " ".join(sys.argv[1:])
+
+mwaa_response = requests.post(
+    mwaa_webserver_hostname,
+    headers={"Authorization": mwaa_auth_token, "Content-Type": "text/plain"},
+    data=raw_data,
+)
+
+mwaa_std_err_message = base64.b64decode(mwaa_response.json()["stderr"]).decode("utf8")
+mwaa_std_out_message = base64.b64decode(mwaa_response.json()["stdout"]).decode("utf8")
+
+print(mwaa_response.status_code)
+print(mwaa_std_err_message)
+print(mwaa_std_out_message)

--- a/airflow/aws_cli.py
+++ b/airflow/aws_cli.py
@@ -5,6 +5,7 @@ Adapted from sample code here:
 https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-cli-command-reference.html#airflow-cli-command-examples
 """
 import base64
+import json
 import sys
 
 import boto3
@@ -26,9 +27,15 @@ mwaa_response = requests.post(
     data=raw_data,
 )
 
-mwaa_std_err_message = base64.b64decode(mwaa_response.json()["stderr"]).decode("utf8")
-mwaa_std_out_message = base64.b64decode(mwaa_response.json()["stdout"]).decode("utf8")
-
 print(mwaa_response.status_code)
-print(mwaa_std_err_message)
-print(mwaa_std_out_message)
+try:
+    mwaa_std_err_message = base64.b64decode(mwaa_response.json()["stderr"]).decode(
+        "utf8"
+    )
+    mwaa_std_out_message = base64.b64decode(mwaa_response.json()["stdout"]).decode(
+        "utf8"
+    )
+    print(mwaa_std_err_message)
+    print(mwaa_std_out_message)
+except json.decoder.JSONDecodeError:
+    print(mwaa_response.text)

--- a/airflow/deploy.sh
+++ b/airflow/deploy.sh
@@ -4,7 +4,12 @@ BUCKET="dse-infra-dev-us-west-2-mwaa"
 ENVIRONMENT="dse-infra-dev-us-west-2-mwaa-environment"
 
 # Copy the dags
-aws s3 sync dags s3://${BUCKET}/dags --delete --exclude "*__pycache__*"
+for SUBDIR in $(ls dags); do
+  if [ $SUBDIR == '__pycache__' ]; then
+      continue
+  fi
+  aws s3 sync dags/$SUBDIR s3://${BUCKET}/dags/$SUBDIR --delete --exclude "*__pycache__*"
+done
 
 # Copy the requirements.txt
 OLD_VERSION=$(aws mwaa get-environment --name $ENVIRONMENT --query 'Environment.RequirementsS3ObjectVersion' --output text)

--- a/airflow/requirements/requirements.txt
+++ b/airflow/requirements/requirements.txt
@@ -1,7 +1,8 @@
 apache-airflow-providers-slack
-apache-airflow-providers-snowflake[slack]
+apache-airflow-providers-snowflake
 backoff
 fsspec
 pdfplumber
 s3fs
-snowflake-connector-python[pandas]
+snowflake-connector-python[pandas]==3.5.0
+pandas==2.0.3

--- a/airflow/requirements/requirements.txt
+++ b/airflow/requirements/requirements.txt
@@ -6,5 +6,5 @@ fsspec
 pandas
 pdfplumber
 pyarrow
-s3fs
+s3fs==2023.9.2
 snowflake-connector-python

--- a/airflow/requirements/requirements.txt
+++ b/airflow/requirements/requirements.txt
@@ -6,5 +6,4 @@ fsspec
 pandas
 pdfplumber
 pyarrow
-s3fs==2023.9.2
 snowflake-connector-python

--- a/airflow/requirements/requirements.txt
+++ b/airflow/requirements/requirements.txt
@@ -1,8 +1,10 @@
+--constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.10.txt
 apache-airflow-providers-slack
 apache-airflow-providers-snowflake
 backoff
 fsspec
+pandas
 pdfplumber
+pyarrow
 s3fs
-snowflake-connector-python[pandas]==3.5.0
-pandas==2.0.3
+snowflake-connector-python

--- a/airflow/requirements/requirements.txt
+++ b/airflow/requirements/requirements.txt
@@ -1,5 +1,7 @@
 apache-airflow-providers-slack
 apache-airflow-providers-snowflake[slack]
 backoff
+fsspec
 pdfplumber
+s3fs
 snowflake-connector-python[pandas]

--- a/terraform/aws/modules/infra/airflow.tf
+++ b/terraform/aws/modules/infra/airflow.tf
@@ -153,13 +153,41 @@ resource "aws_mwaa_environment" "this" {
   schedulers         = 2
   max_workers        = 5
   min_workers        = 1
-  airflow_version    = "2.4.3"
+  airflow_version    = "2.7.2"
 
   airflow_configuration_options = {
     "custom.scratch_bucket"         = aws_s3_bucket.scratch.id
     "custom.default_job_queue"      = aws_batch_job_queue.default.name
     "custom.default_job_definition" = aws_batch_job_definition.default.name
   }
+
+  logging_configuration {
+    dag_processing_logs {
+      enabled   = true
+      log_level = "INFO"
+    }
+
+    scheduler_logs {
+      enabled   = true
+      log_level = "INFO"
+    }
+
+    task_logs {
+      enabled   = true
+      log_level = "INFO"
+    }
+
+    webserver_logs {
+      enabled   = true
+      log_level = "INFO"
+    }
+
+    worker_logs {
+      enabled   = true
+      log_level = "INFO"
+    }
+  }
+
 
   source_bucket_arn    = aws_s3_bucket.mwaa.arn
   dag_s3_path          = "dags/"


### PR DESCRIPTION
In working on https://github.com/cagov/caldata-mdsa-caltrans-pems/issues/18, I found there were a few maintenance-related things I had to do to make our Airflow instance healthy after being unused for a few months:

* Add a convenience script for interacting with the MWAA CLI (for things that can't be done via the web UI)
* Turn on logging for better debugging when things go wrong
* Bump the version to 2.7.2
* Include an appropriate [constraints](https://airflow.apache.org/docs/apache-airflow/stable/installation/installing-from-pypi.html#constraints-files) file when specifying python dependencies.