### PR TITLE
Add ruff formatter.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,18 +42,12 @@ repos:
             "--output-file",
             "../../../../docs/snowflake.md",
           ]
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-      - id: black
-        language_version: python3
-        args:
-          - --target-version=py310
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.259
+    rev: v0.1.6
     hooks:
       - id: ruff
         args: [--show-source, --fix]
+      - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.4
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ ignore = [
   "D203", # blank line before docstring
   "D212", # Start multi-line docstring at the second line.
   "E501", # line length handled by black
+  "ISC001", # Handled by formatter
   "PGH003", # specific mypy ignore codes
   "PLR0913", # too many arguments
   "PLR0912", # too many branches


### PR DESCRIPTION
This removes the black formatter in favor of ruff's allowing us to drop one tool . It's supposed to be a drop-in replacement, so no further updates are needed.

Fixes #239 