### PR TITLE
Move building footprints pipeline to PRD snowflake environment

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,9 +1,6 @@
-name: deploy
+name: Build Image
 
-on:
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
   deploy:
@@ -33,7 +30,7 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: dse-infra-dev-us-west-2-default
-          IMAGE_TAG: latest
+          IMAGE_TAG: ${{ github.ref == 'refs/heads/main' && 'latest' || 'test' }}
         with:
           push: true
           context: "."

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,7 +3,7 @@ name: Build Image
 on: push
 
 jobs:
-  deploy:
+  build-image:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/submit-job.yml
+++ b/.github/workflows/submit-job.yml
@@ -25,7 +25,7 @@ jobs:
           aws batch submit-job \
           --job-name test \
           --job-queue dse-infra-dev-us-west-2-default \
-          --job-definition dse-infra-dev-us-west-2-default \
+          --job-definition dse-infra-dev-us-west-2-default-latest \
           --container-overrides '{
             "resourceRequirements":
             [{"value": "2", "type": "VCPU"}, {"value": "4096", "type": "MEMORY"}],

--- a/docs/cloud-infrastructure.md
+++ b/docs/cloud-infrastructure.md
@@ -238,6 +238,7 @@ No modules.
 | [aws_iam_policy_document.s3_list_all_my_buckets](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_scratch_policy_document](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.self_manage_credentials](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_secretsmanager_secret.snowflake_loader_secret](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/secretsmanager_secret) | data source |
 
 ## Inputs
 
@@ -247,7 +248,7 @@ No modules.
 | <a name="input_owner"></a> [owner](#input\_owner) | Owner of the resource | `string` | `"dse"` | no |
 | <a name="input_project"></a> [project](#input\_project) | Name of the project the resource is serving | `string` | `"infra"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region for AWS resources | `string` | `"us-west-2"` | no |
-| <a name="input_snowflake_loader_secret"></a> [snowflake\_loader\_secret](#input\_snowflake\_loader\_secret) | ARN for SecretsManager login info to Snowflake with loader role | `string` | `null` | no |
+| <a name="input_snowflake_loader_secret"></a> [snowflake\_loader\_secret](#input\_snowflake\_loader\_secret) | ARN for SecretsManager login info to Snowflake with loader role | `object({ test = string, latest = string })` | `null` | no |
 
 ## Outputs
 

--- a/jobs/geo/write_building_footprints.py
+++ b/jobs/geo/write_building_footprints.py
@@ -17,7 +17,7 @@ def write_building_footprints(conn, kind: str):
     conn.cursor().execute(sql_alter)
 
     ref = (
-        "ANALYTICS_DEV.ANALYTICS"
+        "ANALYTICS_PRD.BUILDING_FOOTPRINTS"
         f".GEO_REFERENCE__{kind.upper()}_BUILDING_FOOTPRINTS_WITH_TIGER"
     )
     sql_counties = f"""

--- a/terraform/aws/environments/dev/main.tf
+++ b/terraform/aws/environments/dev/main.tf
@@ -46,8 +46,11 @@ provider "aws" {
 module "infra" {
   source = "../../modules/infra"
 
-  owner                   = local.owner
-  environment             = local.environment
-  project                 = local.project
-  snowflake_loader_secret = "arn:aws:secretsmanager:us-west-2:676096391788:secret:dse-snowflake-dev-us-west-2-loader-q1kChm"
+  owner       = local.owner
+  environment = local.environment
+  project     = local.project
+  snowflake_loader_secret = {
+    test   = "dse-snowflake-dev-us-west-2-loader"
+    latest = "dse-snowflake-prd-us-west-2-loader"
+  }
 }

--- a/terraform/aws/modules/infra/airflow.tf
+++ b/terraform/aws/modules/infra/airflow.tf
@@ -156,9 +156,10 @@ resource "aws_mwaa_environment" "this" {
   airflow_version    = "2.7.2"
 
   airflow_configuration_options = {
-    "custom.scratch_bucket"         = aws_s3_bucket.scratch.id
-    "custom.default_job_queue"      = aws_batch_job_queue.default.name
-    "custom.default_job_definition" = aws_batch_job_definition.default.name
+    "custom.scratch_bucket"    = aws_s3_bucket.scratch.id
+    "custom.default_job_queue" = aws_batch_job_queue.default.name
+    # Note: default job definition to the "latest", rather than the "test" environment.
+    "custom.default_job_definition" = aws_batch_job_definition.default["latest"].name
   }
 
   logging_configuration {

--- a/terraform/aws/modules/infra/iam.tf
+++ b/terraform/aws/modules/infra/iam.tf
@@ -66,18 +66,20 @@ resource "aws_iam_policy" "self_manage_credentials" {
 }
 
 data "aws_iam_policy_document" "access_snowflake_loader" {
+  for_each = toset(local.jobs)
   statement {
     actions = ["secretsmanager:GetSecretValue"]
     resources = [
-      var.snowflake_loader_secret
+      data.aws_secretsmanager_secret.snowflake_loader_secret[each.key].arn
     ]
   }
 }
 
 resource "aws_iam_policy" "access_snowflake_loader" {
-  name        = "${local.prefix}-access-snowflake-loader"
-  description = "Allow a user/role to access Snowflake loader role in SecretsManager"
-  policy      = data.aws_iam_policy_document.access_snowflake_loader.json
+  for_each    = toset(local.jobs)
+  name        = "${local.prefix}-access-snowflake-loader-${each.key}"
+  description = "Allow a user/role to access Snowflake loader role in SecretsManager for the ${each.key} secret"
+  policy      = data.aws_iam_policy_document.access_snowflake_loader[each.key].json
 }
 
 ##################################

--- a/terraform/aws/modules/infra/outputs.tf
+++ b/terraform/aws/modules/infra/outputs.tf
@@ -1,11 +1,14 @@
 output "state" {
   description = "Resources from terraform-state"
   value = {
-    repository_url       = aws_ecr_repository.default.repository_url
-    scratch_bucket       = aws_s3_bucket.scratch.id
-    mwaa_bucket          = aws_s3_bucket.mwaa.id
-    github_actions_bot   = aws_iam_user.cd_bot.name
-    batch_job_queue      = aws_batch_job_queue.default.name
-    batch_job_definition = aws_batch_job_definition.default.name
+    repository_url     = aws_ecr_repository.default.repository_url
+    scratch_bucket     = aws_s3_bucket.scratch.id
+    mwaa_bucket        = aws_s3_bucket.mwaa.id
+    github_actions_bot = aws_iam_user.cd_bot.name
+    batch_job_queue    = aws_batch_job_queue.default.name
+    batch_job_definitions = {
+      test   = aws_batch_job_definition.default["test"].name
+      latest = aws_batch_job_definition.default["latest"].name
+    }
   }
 }

--- a/terraform/aws/modules/infra/secrets.tf
+++ b/terraform/aws/modules/infra/secrets.tf
@@ -1,0 +1,14 @@
+##################################
+#      AWS Secrets Manager       #
+##################################
+
+locals {
+  snowflake_data = ["account", "user", "database", "warehouse", "role", "password"]
+
+  jobs = ["test", "latest"]
+}
+
+data "aws_secretsmanager_secret" "snowflake_loader_secret" {
+  for_each = toset(local.jobs)
+  name     = var.snowflake_loader_secret[each.key]
+}

--- a/terraform/aws/modules/infra/variables.tf
+++ b/terraform/aws/modules/infra/variables.tf
@@ -24,7 +24,7 @@ variable "region" {
 
 variable "snowflake_loader_secret" {
   description = "ARN for SecretsManager login info to Snowflake with loader role"
-  type        = string
+  type        = object({ test = string, latest = string })
   default     = null
 }
 

--- a/transform/models/marts/geo_reference/_geo_reference__models.yml
+++ b/transform/models/marts/geo_reference/_geo_reference__models.yml
@@ -3,7 +3,8 @@ version: 2
 sources:
   - name: building_footprints
     database: "{{ env_var('DBT_RAW_DB', 'RAW_DEV') }}"
-    schema: building_footprints
+    config:
+      schema: building_footprints
     tables:
       - name: us_building_footprints
         description: "[Microsoft US Building Footprints]\
@@ -24,7 +25,8 @@ sources:
 
 models:
   - name: geo_reference__us_building_footprints_with_tiger
-    schema: building_footprints
+    config:
+      schema: building_footprints
     description: |
       This data table is a join of the TIGER data for blocks, tracts, counties, and
       places with the Microsoft US Building Footprints data for the state of CA.

--- a/transform/models/marts/geo_reference/_geo_reference__models.yml
+++ b/transform/models/marts/geo_reference/_geo_reference__models.yml
@@ -24,6 +24,7 @@ sources:
 
 models:
   - name: geo_reference__us_building_footprints_with_tiger
+    schema: building_footprints
     description: |
       This data table is a join of the TIGER data for blocks, tracts, counties, and
       places with the Microsoft US Building Footprints data for the state of CA.
@@ -63,6 +64,7 @@ models:
       - name: area_sqm
         description: The area of the footprint in square meters
   - name: geo_reference__global_ml_building_footprints_with_tiger
+    schema: building_footprints
     description: |
       This data table is a join of the TIGER data for blocks, tracts, counties, and
       places with the Microsoft Global ML Building Footprints data for the state of CA.


### PR DESCRIPTION
Fixes #251 

This is a little more involved than the issue description would suggest: we have been running the data ingest in AWS Batch jobs, and our default job definition currently has access to our Snowflake LOADER_DEV role. So I've restructured our Batch set-up a little bit:

1. There are now *two* batch job definitions, a "test" definition, and a "latest". The "latest" definition has access to the PRD role, and the "test" definition has access to the DEV role.
2. Two different docker images are built with different tags: `latest` is built on merges to `main`, while `test` is built on pushes to feature branches. This is a small step towards implementing #247, though I wouldn't consider this fixing it.
3. The "test" job definition and docker image are intended to be used for developing new Batch jobs, "latest" is intended to be run in production by MWAA.

This new Batch set-up could have been done instead in a new AWS account, where we have stronger separation between dev/prod and a whole new Airflow deployment (cf. #119). That felt premature to me, however, and I think there's value in having some dev/test separation for batch jobs even in our "dev" environment. I'm open to push-back here, though!