### PR TITLE
Schedule downstream footprint tasks

### DIFF
--- a/.github/workflows/submit-job.yml
+++ b/.github/workflows/submit-job.yml
@@ -25,10 +25,8 @@ jobs:
           aws batch submit-job \
           --job-name test \
           --job-queue dse-infra-dev-us-west-2-default \
-          --job-definition dse-infra-dev-us-west-2-default-latest \
+          --job-definition dse-infra-dev-us-west-2-latest \
           --container-overrides '{
             "resourceRequirements":
-            [{"value": "2", "type": "VCPU"}, {"value": "4096", "type": "MEMORY"}],
-            "environment":
-            [{"name": "BUCKET", "value": "dse-infra-dev-us-west-2-scratch"}]
+            [{"value": "2", "type": "VCPU"}, {"value": "4096", "type": "MEMORY"}]
           }'

--- a/airflow/dags/geo_reference/load_building_footprints.py
+++ b/airflow/dags/geo_reference/load_building_footprints.py
@@ -63,7 +63,7 @@ def building_footprints_dag():
     )
 
     run_dbt_cloud_job = DbtCloudRunJobOperator(
-        job_id=None,
+        job_id=14,
         task_id="run_dbt_cloud_job",
         dbt_cloud_conn_id="dbt_cloud_default",
         wait_for_termination=True,

--- a/airflow/dags/geo_reference/load_building_footprints.py
+++ b/airflow/dags/geo_reference/load_building_footprints.py
@@ -11,6 +11,23 @@ from airflow.providers.amazon.aws.operators.batch import BatchOperator
 from airflow.providers.amazon.aws.sensors.batch import BatchSensor
 
 
+def _construct_batch_args(name: str, command: list[str]) -> dict:
+    return {
+        "task_id": name,
+        "job_name": name,
+        "job_queue": os.environ["AIRFLOW__CUSTOM__DEFAULT_JOB_QUEUE"],
+        "job_definition": os.environ["AIRFLOW__CUSTOM__DEFAULT_JOB_DEFINITION"],
+        "overrides": {
+            "command": command,
+            "resourceRequirements": [
+                {"type": "VCPU", "value": "8"},
+                {"type": "MEMORY", "value": "32768"},
+            ],
+        },
+        "region_name": "us-west-2",  # TODO: can we make this unnecessary?
+    }
+
+
 @dag(
     description="Test DAG",
     start_date=datetime(2023, 5, 23),
@@ -20,45 +37,57 @@ from airflow.providers.amazon.aws.sensors.batch import BatchSensor
 )
 def building_footprints_dag():
     """DAG for loading MS Building footprints dataset."""
-    submit_batch_job_us = BatchOperator(
-        task_id="load_us_footprints",
-        job_name="us_building_footprints",
-        job_queue=os.environ["AIRFLOW__CUSTOM__DEFAULT_JOB_QUEUE"],
-        job_definition=os.environ["AIRFLOW__CUSTOM__DEFAULT_JOB_DEFINITION"],
-        overrides={
-            "command": ["python", "-m", "jobs.geo.load_us_building_footprints"],
-            "resourceRequirements": [
-                {"type": "VCPU", "value": "8"},
-                {"type": "MEMORY", "value": "32768"},
-            ],
-        },
-        region_name="us-west-2",  # TODO: can we make this unnecessary?
+    load_us_footprints = BatchOperator(
+        **_construct_batch_args(
+            name="load_us_building_footprints",
+            command=["python", "-m", "jobs.geo.load_us_building_footprints"],
+        )
     )
-    _ = BatchSensor(
-        task_id="wait_for_batch_job_us",
-        job_id=submit_batch_job_us.output,
+    wait_for_us_footprints_load = BatchSensor(
+        task_id="wait_for_us_footprints_load",
+        job_id=load_us_footprints.output,
         region_name="us-west-2",  # TODO: can we make this unnecessary?
     )
 
-    submit_batch_job_global_ml = BatchOperator(
-        task_id="load_global_ml_footprints",
-        job_name="global_ml_building_footprints",
-        job_queue=os.environ["AIRFLOW__CUSTOM__DEFAULT_JOB_QUEUE"],
-        job_definition=os.environ["AIRFLOW__CUSTOM__DEFAULT_JOB_DEFINITION"],
-        overrides={
-            "command": ["python", "-m", "jobs.geo.load_global_ml_building_footprints"],
-            "resourceRequirements": [
-                {"type": "VCPU", "value": "8"},
-                {"type": "MEMORY", "value": "32768"},
-            ],
-        },
+    unload_us_footprints = BatchOperator(
+        **_construct_batch_args(
+            name="unload_us_building_footprints",
+            command=["python", "-m", "jobs.geo.write_building_footprints", "us"],
+        )
+    )
+    _ = BatchSensor(
+        task_id="wait_for_us_footprints_unload",
+        job_id=unload_us_footprints.output,
         region_name="us-west-2",  # TODO: can we make this unnecessary?
     )
-    __ = BatchSensor(
-        task_id="wait_for_batch_job_global_ml",
-        job_id=submit_batch_job_global_ml.output,
+
+    unload_us_footprints.set_upstream(wait_for_us_footprints_load)
+
+    load_global_ml_footprints = BatchOperator(
+        **_construct_batch_args(
+            name="load_global_ml_building_footprints",
+            command=["python", "-m", "jobs.geo.load_global_ml_building_footprints"],
+        )
+    )
+    wait_for_global_ml_footprints_unload = BatchSensor(
+        task_id="wait_for_global_ml_footprints_load",
+        job_id=load_global_ml_footprints.output,
         region_name="us-west-2",  # TODO: can we make this unnecessary?
     )
+
+    unload_global_ml_footprints = BatchOperator(
+        **_construct_batch_args(
+            name="unload_global_ml_building_footprints",
+            command=["python", "-m", "jobs.geo.write_building_footprints", "global_ml"],
+        )
+    )
+    _ = BatchSensor(
+        task_id="wait_for_global_ml_footprints_unload",
+        job_id=unload_global_ml_footprints.output,
+        region_name="us-west-2",  # TODO: can we make this unnecessary?
+    )
+
+    unload_global_ml_footprints.set_upstream(wait_for_global_ml_footprints_unload)
 
 
 run = building_footprints_dag()

--- a/airflow/requirements/requirements.txt
+++ b/airflow/requirements/requirements.txt
@@ -2,6 +2,8 @@
 apache-airflow-providers-slack
 apache-airflow-providers-snowflake
 backoff
+dbt-core==1.6.9
+dbt-snowflake==1.6.6
 fsspec
 pandas
 pdfplumber

--- a/airflow/requirements/requirements.txt
+++ b/airflow/requirements/requirements.txt
@@ -2,8 +2,6 @@
 apache-airflow-providers-slack
 apache-airflow-providers-snowflake
 backoff
-dbt-core==1.6.9
-dbt-snowflake==1.6.6
 fsspec
 pandas
 pdfplumber

--- a/airflow/requirements/requirements.txt
+++ b/airflow/requirements/requirements.txt
@@ -1,4 +1,5 @@
 --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.10.txt
+apache-airflow-providers-dbt-cloud
 apache-airflow-providers-slack
 apache-airflow-providers-snowflake
 backoff

--- a/docs/cloud-infrastructure.md
+++ b/docs/cloud-infrastructure.md
@@ -177,6 +177,7 @@ No modules.
 | [aws_iam_policy.access_snowflake_loader](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.batch_submit_policy](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.default_ecr_policy](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.dof_demographics_read_write_access](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.mwaa](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3_dsa_project_policy](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3_list_all_my_buckets](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_policy) | resource |
@@ -187,6 +188,7 @@ No modules.
 | [aws_iam_role.ecs_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_role) | resource |
 | [aws_iam_role.mwaa](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.aws_batch_service_role](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.dof_demographics_read_write_access](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ecs_task_execution_access_snowflake_loader](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ecs_task_execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.mwaa_batch_submit_role](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/resources/iam_role_policy_attachment) | resource |
@@ -233,6 +235,7 @@ No modules.
 | [aws_iam_policy_document.batch_submit_policy_document](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.default_ecr_policy_document](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dof_demographics_public_read_access](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.dof_demographics_read_write_access](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.mwaa](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_dsa_project_policy_document](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_list_all_my_buckets](https://registry.terraform.io/providers/hashicorp/aws/4.56.0/docs/data-sources/iam_policy_document) | data source |

--- a/jobs/geo/write_building_footprints.py
+++ b/jobs/geo/write_building_footprints.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     os.environ["SNOWFLAKE_ROLE"] = os.environ["SNOWFLAKE_ROLE"].replace(
         "LOADER", "REPORTER"
     )
-    os.environ["SNOWFLAKE_WAREHOUSE"] = os.environ["SNOWFLAKE_ROLE"].replace(
+    os.environ["SNOWFLAKE_WAREHOUSE"] = os.environ["SNOWFLAKE_WAREHOUSE"].replace(
         "LOADING", "REPORTING"
     )
 

--- a/terraform/aws/modules/infra/batch.tf
+++ b/terraform/aws/modules/infra/batch.tf
@@ -84,6 +84,11 @@ resource "aws_iam_role_policy_attachment" "s3_scratch_policy_role_attachment" {
   policy_arn = aws_iam_policy.s3_scratch_policy.arn
 }
 
+resource "aws_iam_role_policy_attachment" "dof_demographics_read_write_access" {
+  role       = aws_iam_role.batch_job_role.name
+  policy_arn = aws_iam_policy.dof_demographics_read_write_access.arn
+}
+
 resource "aws_batch_job_queue" "default" {
   name     = "${local.prefix}-${var.region}-default"
   state    = "ENABLED"

--- a/terraform/aws/modules/infra/s3.tf
+++ b/terraform/aws/modules/infra/s3.tf
@@ -110,6 +110,31 @@ resource "aws_s3_bucket_policy" "dof_demographics_public_read_access" {
   policy = data.aws_iam_policy_document.dof_demographics_public_read_access.json
 }
 
+data "aws_iam_policy_document" "dof_demographics_read_write_access" {
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+
+    resources = [aws_s3_bucket.dof_demographics_public.arn]
+  }
+  statement {
+    actions = [
+      "s3:*Object",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.dof_demographics_public.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "dof_demographics_read_write_access" {
+  name        = "${aws_s3_bucket.dof_demographics_public.id}-read-write"
+  description = "Read/write access to the ${aws_s3_bucket.dof_demographics_public.id} bucket"
+  policy      = data.aws_iam_policy_document.dof_demographics_read_write_access.json
+}
+
 resource "aws_s3_bucket_public_access_block" "dof_demographics_public" {
   bucket = aws_s3_bucket.dof_demographics_public.id
 

--- a/transform/models/marts/geo_reference/_geo_reference__models.yml
+++ b/transform/models/marts/geo_reference/_geo_reference__models.yml
@@ -27,6 +27,7 @@ models:
   - name: geo_reference__us_building_footprints_with_tiger
     config:
       schema: building_footprints
+      tags: building_footprints
     description: |
       This data table is a join of the TIGER data for blocks, tracts, counties, and
       places with the Microsoft US Building Footprints data for the state of CA.
@@ -68,6 +69,7 @@ models:
   - name: geo_reference__global_ml_building_footprints_with_tiger
     config:
       schema: building_footprints
+      tags: building_footprints
     description: |
       This data table is a join of the TIGER data for blocks, tracts, counties, and
       places with the Microsoft Global ML Building Footprints data for the state of CA.

--- a/transform/models/marts/geo_reference/_geo_reference__models.yml
+++ b/transform/models/marts/geo_reference/_geo_reference__models.yml
@@ -66,7 +66,8 @@ models:
       - name: area_sqm
         description: The area of the footprint in square meters
   - name: geo_reference__global_ml_building_footprints_with_tiger
-    schema: building_footprints
+    config:
+      schema: building_footprints
     description: |
       This data table is a join of the TIGER data for blocks, tracts, counties, and
       places with the Microsoft Global ML Building Footprints data for the state of CA.


### PR DESCRIPTION
Fixes #250 

Previously, we were only scheduling the data load of building footprints. The dbt build was left for a "nightly" job, and the data unload to geoparquet/shapefile was done manually.

This incorporates the dbt build for footprints as well as the data unloading step into the Airflow dag so that it's more of an end-to-end pipeline. I'm triggering the dbt build using the `DbtCloudJobRunOperator`, which talks directly to environments and jobs in dbt cloud. We could also do this with dbt core, and reworking things to do that would be an interesting exercise. For the moment, however, using dbt cloud was simpler.