### PR TITLE
Josh doc updates

### DIFF
--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,6 +1,6 @@
 # Conventions for Code Review and GitHub
 
-This page documents the Data Services and Engineering Team's practices around GitHub-based development and code review..
+This page documents the Data Services and Engineering Team's practices around GitHub-based development and code review.
 
 ## Creating a Pull Request
 

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,6 +1,6 @@
 # Conventions for Code Review and GitHub
 
-This page documents the Data Services and Engineering Team's practices around GitHub-based development and code review.
+This page documents the Data Services and Engineering Team's practices around GitHub-based development and code review..
 
 ## Creating a Pull Request
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,9 +23,9 @@ Here are instructions for setting up a Python environment using Miniconda:
    conda create -n infra -c conda-forge python=3.10 poetry
    ```
 
-   The following pronpt will appear, "_The following NEW packages will be INSTALLED:_ "
+   The following prompt will appear, "_The following NEW packages will be INSTALLED:_ "
    You'll have the option to accept or reject by typing _y_ or _n_. Type _y_ to continue.
-3. Activate the `infra` environment:
+   3. Activate the `infra` environment:
    ```bash
    conda activate infra
    ```
@@ -34,7 +34,7 @@ Here are instructions for setting up a Python environment using Miniconda:
 
 Python dependencies are specified using [`poetry`](https://python-poetry.org/).
 
-To install them, open a terminal and ensure you are working in the data-infrastructure repo folder, then enter the following:
+To install them, open a terminal and ensure you are working in the data-infrastructure root folder, then enter the following:
 
 ```bash
 poetry install --with dev --no-root

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,9 +24,8 @@ Here are instructions for setting up a Python environment using Miniconda:
    ```
 
    The following pronpt will appear, "_The following NEW packages will be INSTALLED:_ "
-   You'll have the option to accept or reject by typing _y_ or _n_. Type _y_
-3.
-4. Activate the `infra` environment:
+   You'll have the option to accept or reject by typing _y_ or _n_. Type _y_ to continue.
+3. Activate the `infra` environment:
    ```bash
    conda activate infra
    ```
@@ -35,10 +34,10 @@ Here are instructions for setting up a Python environment using Miniconda:
 
 Python dependencies are specified using [`poetry`](https://python-poetry.org/).
 
-To install them, open a terminal and enter:
+To install them, open a terminal and ensure you are working in the data-infrastructure repo folder, then enter the following:
 
 ```bash
-poetry install
+poetry install --with dev --no-root
 ```
 
 Any time the dependencies change, you can re-run the above command to update them.
@@ -196,7 +195,7 @@ This project uses [pre-commit](https://pre-commit.com/) to lint, format,
 and generally enforce code quality. These checks are run on every commit,
 as well as in CI.
 
-To set up your pre-commit environment locally run
+To set up your pre-commit environment locally run the following in the data-infrastructure repo root folder:
 
 ```bash
 pre-commit install

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,10 +22,9 @@ Here are instructions for setting up a Python environment using Miniconda:
    ```bash
    conda create -n infra -c conda-forge python=3.10 poetry
    ```
-
    The following prompt will appear, "_The following NEW packages will be INSTALLED:_ "
    You'll have the option to accept or reject by typing _y_ or _n_. Type _y_ to continue.
-   3. Activate the `infra` environment:
+3. Activate the `infra` environment:
    ```bash
    conda activate infra
    ```


### PR DESCRIPTION
Updated the following in the data-infrastructure Project Setup page:

- Set up python virtual environment section: there was an extra numbered bullet which I removed. 
- Install Python dependencies section: updated poetry install code to include --with dev --no-root and specified the user should be in the data-infrastructure repo folder
- Installing pre-commit hooks section: specified the user should be in the data infrastructure repo folder

Also I could not get the third bullet in the "Set up python virtual environment" section to go to a new line successfully in the preview doc. This was already happening in the original version. 