### PR TITLE
Update terraform CI to execute in its own job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,14 +23,6 @@ jobs:
       - uses: snok/install-poetry@v1
         with:
           virtualenvs-create: false
-      - name: Setup terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: v1.4.0
-      - name: Install tflint
-        run: |
-          curl -s https://raw.githubusercontent.com/terraform-linters/\
-          tflint/master/install_linux.sh | bash
       - name: Install dependencies
         run: |
           poetry install

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -1,0 +1,62 @@
+name: terraform-validation
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  terraform-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: v1.4.0
+      - name: Install tflint
+        run: |
+          curl -s https://raw.githubusercontent.com/terraform-linters/\
+          tflint/master/install_linux.sh | bash
+
+      - name: Run terraform fmt
+        run: |
+          terraform fmt
+      - name: Run terraform validate
+        run: |
+          terraform validate
+      - name: Run terraform tflint
+        run: |
+          tflint --chdir=terraform/ --recursive
+
+      - name: Document cloud infrastructure remote state in README
+        uses: terraform-docs/gh-actions@v1.3.0
+        with:
+          working-dir: ./terraform/s3-remote-state
+      - name: Document cloud infrastructure in mkdocs
+        uses: terraform-docs/gh-actions@v1.3.0
+        with:
+          working-dir: ./terraform/aws/modules/infra
+          output-file: ../../../../docs/code/terraform-local-setup.md
+      - name: Document Snowflake account infrastructure in mkdocs
+        uses: terraform-docs/gh-actions@v1.3.0
+        with:
+          working-dir: ./terraform/snowflake/modules/elt
+          output-file: ../../../../docs/infra/snowflake.md
+      # This shouldn't be necessary but the terraform-docs action has a bug
+      # preventing it from git-adding files outside of 'working-dir'.
+      # See: https://github.com/terraform-docs/gh-actions/pull/108
+      - name: Commit any files changed by terraform-docs
+        run: |
+          git add docs/code/terraform-local-setup.md
+          git add docs/infra/snowflake.md
+          # Run git commit if changed files are detected
+          if git status --porcelain | grep -q '[AM ][AM ]\s\+\S\+'; then
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            set -x
+            git commit -m "Automated terraform-docs commit"
+            git push
+            set +x
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,37 +11,6 @@ repos:
       - id: check-merge-conflict
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_validate
-        # Exclude modules to work around
-        # https://github.com/hashicorp/terraform/issues/28490
-        exclude: "terraform/[^/]+/modules/[^/]+/[^/]+$"
-      - id: terraform_tflint
-  - repo: https://github.com/terraform-docs/terraform-docs
-    rev: v0.16.0
-    hooks:
-      - id: terraform-docs-go
-        name: Document cloud infrastructure remote state in README
-        args: ["./terraform/s3-remote-state"]
-      - id: terraform-docs-go
-        name: Document cloud infrastructure in mkdocs
-        args:
-          [
-            "./terraform/aws/modules/infra/",
-            "--output-file",
-            "../../../../docs/cloud-infrastructure.md",
-          ]
-      - id: terraform-docs-go
-        name: Document Snowflake account infrastructure in mkdocs
-        args:
-          [
-            "./terraform/snowflake/modules/elt/",
-            "--output-file",
-            "../../../../docs/snowflake.md",
-          ]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.1.6
     hooks:


### PR DESCRIPTION
Fixes #319 

This ended up being more painful than the related task in Caltrans' repo due to the terraform-docs automation. The terraform-docs action works for our use case, though it requires 1 invocation per file and also has a bug [(see use of $OUTPUT_FILE here)](https://github.com/terraform-docs/gh-actions/pull/108) that means it only fully works on 1 of our 3 files. 