### PR TITLE
Changes for upgrading terraform snowflake provider from 0.92 to 0.97

### DIFF
--- a/terraform/snowflake/environments/dev/.terraform.lock.hcl
+++ b/terraform/snowflake/environments/dev/.terraform.lock.hcl
@@ -2,23 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/snowflake-labs/snowflake" {
-  version     = "0.92.0"
-  constraints = "~> 0.88, 0.92.0"
+  version     = "0.97.0"
+  constraints = "~> 0.88, 0.97.0"
   hashes = [
-    "h1:gEss1CYtwBknBv7k+qjk+dBz7XwGyl7YQi1MDYkYGZg=",
-    "h1:iZa/QVqOFfxqJwvvJQyExkS1ZW4FDiR+q7JdUkCW3iY=",
-    "h1:yHFALpBAbt+cJIwR42uuVECmYuWUMChSrGiPejW+ySE=",
-    "zh:5243cc31b0d761406009a943c713e2148543f982cb0376efc721a5b4dee16802",
-    "zh:7a79a12ee3022ae8105eb8efee562873bbfa9518acdf2bb572cfef40a107f962",
-    "zh:7f780ebc8cbaa319ccd0c93cc52cacc0966cb4fc036895ae7c7eeabc7983f275",
-    "zh:a30c5bb1057cc94948c1c06e361081b310a37a1625a795c3122e286b1ba4ad5d",
-    "zh:bc826239bffba37743b10abc36350cede21481b434221a1bc49e0cb1828a176d",
-    "zh:cbbcfd9e5f0fa51d90adf51e70185db3136b0fd558ae0794eccf6884cac111b2",
-    "zh:d285091bea835c69cc5a1e4689f0cafa95b9b68d85042a52dd49311f8753c078",
-    "zh:d45b2685e9fecd8b32fb43090b8b7f19541a34addf64468e646a5b6347188d5d",
-    "zh:d668770a1ecc7e39688816b3aaa551802958bac07c36a67ceab3791d06e2412d",
-    "zh:dd870eec408f2fc2c8f907ddab3192fc8bde15dc4d205c3587fee68b8636ad7a",
+    "h1:/F0ebT46lTn9H99QFsmrRT8r7cKbIawReCf7FTBu97w=",
+    "h1:75erCna4T1emBTQNa2k5kAGUzSx0QV/nF8OpduiY1PQ=",
+    "h1:ZlFADLRJiSHXv3bFLduAPf4K42jbxVg6oGqS82qOg04=",
+    "zh:1460e288a728a86b2403fce71bf42d030cd650a741ae56a2aba5b064e387a6ad",
+    "zh:27b4be2a9983d2fc9763812c1c367824d5ca346e0350705134183507df6912ff",
+    "zh:61a54a281527955132bb27834345a8a204e1b7c8374c2003b034d805409da807",
+    "zh:6d7fc215afb602b5432281c95ce5928564200f0262e8e02032fbb2efc1de9f1c",
+    "zh:85aa756b01a132a5583617cc4e44d00fedb1122c3a7b3389248cd15294f9244b",
+    "zh:90f66a274785eb925e74406b0d3e25fd05630dff21c08ec134154564bc7f9786",
+    "zh:9920888cfdcaeb3b41234080d56053593ab4fcde01e1c034db3a55b86a25c5b7",
+    "zh:b23e346050eb3b56388358135182a0b1898ed526f38e01a05777ec665b2814e4",
+    "zh:d71eada5565cb96bcd566b4f938621b6326309da0058ee5de196c7e8ce0d69c3",
+    "zh:e1d00fc42954a55cfebcc61e876ee751ea49af6027b58988d6545d17b24eeee4",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:f9807dfec6d9ce60b12fe86a5dc1dfdd38a3bf85d8de8df2f5485cd9dde28263",
+    "zh:f5c7422166c97b89240603b05a6280a5123ace2886701877a0b6e30c659a109b",
   ]
 }

--- a/terraform/snowflake/environments/dev/main.tf
+++ b/terraform/snowflake/environments/dev/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "0.92"
+      version = "0.97"
     }
   }
   required_version = ">= 1.0"

--- a/terraform/snowflake/environments/prd/.terraform.lock.hcl
+++ b/terraform/snowflake/environments/prd/.terraform.lock.hcl
@@ -2,23 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/snowflake-labs/snowflake" {
-  version     = "0.92.0"
-  constraints = "~> 0.88, 0.92.0"
+  version     = "0.97.0"
+  constraints = "~> 0.88, 0.97.0"
   hashes = [
-    "h1:gEss1CYtwBknBv7k+qjk+dBz7XwGyl7YQi1MDYkYGZg=",
-    "h1:iZa/QVqOFfxqJwvvJQyExkS1ZW4FDiR+q7JdUkCW3iY=",
-    "h1:yHFALpBAbt+cJIwR42uuVECmYuWUMChSrGiPejW+ySE=",
-    "zh:5243cc31b0d761406009a943c713e2148543f982cb0376efc721a5b4dee16802",
-    "zh:7a79a12ee3022ae8105eb8efee562873bbfa9518acdf2bb572cfef40a107f962",
-    "zh:7f780ebc8cbaa319ccd0c93cc52cacc0966cb4fc036895ae7c7eeabc7983f275",
-    "zh:a30c5bb1057cc94948c1c06e361081b310a37a1625a795c3122e286b1ba4ad5d",
-    "zh:bc826239bffba37743b10abc36350cede21481b434221a1bc49e0cb1828a176d",
-    "zh:cbbcfd9e5f0fa51d90adf51e70185db3136b0fd558ae0794eccf6884cac111b2",
-    "zh:d285091bea835c69cc5a1e4689f0cafa95b9b68d85042a52dd49311f8753c078",
-    "zh:d45b2685e9fecd8b32fb43090b8b7f19541a34addf64468e646a5b6347188d5d",
-    "zh:d668770a1ecc7e39688816b3aaa551802958bac07c36a67ceab3791d06e2412d",
-    "zh:dd870eec408f2fc2c8f907ddab3192fc8bde15dc4d205c3587fee68b8636ad7a",
+    "h1:/F0ebT46lTn9H99QFsmrRT8r7cKbIawReCf7FTBu97w=",
+    "h1:75erCna4T1emBTQNa2k5kAGUzSx0QV/nF8OpduiY1PQ=",
+    "h1:ZlFADLRJiSHXv3bFLduAPf4K42jbxVg6oGqS82qOg04=",
+    "zh:1460e288a728a86b2403fce71bf42d030cd650a741ae56a2aba5b064e387a6ad",
+    "zh:27b4be2a9983d2fc9763812c1c367824d5ca346e0350705134183507df6912ff",
+    "zh:61a54a281527955132bb27834345a8a204e1b7c8374c2003b034d805409da807",
+    "zh:6d7fc215afb602b5432281c95ce5928564200f0262e8e02032fbb2efc1de9f1c",
+    "zh:85aa756b01a132a5583617cc4e44d00fedb1122c3a7b3389248cd15294f9244b",
+    "zh:90f66a274785eb925e74406b0d3e25fd05630dff21c08ec134154564bc7f9786",
+    "zh:9920888cfdcaeb3b41234080d56053593ab4fcde01e1c034db3a55b86a25c5b7",
+    "zh:b23e346050eb3b56388358135182a0b1898ed526f38e01a05777ec665b2814e4",
+    "zh:d71eada5565cb96bcd566b4f938621b6326309da0058ee5de196c7e8ce0d69c3",
+    "zh:e1d00fc42954a55cfebcc61e876ee751ea49af6027b58988d6545d17b24eeee4",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:f9807dfec6d9ce60b12fe86a5dc1dfdd38a3bf85d8de8df2f5485cd9dde28263",
+    "zh:f5c7422166c97b89240603b05a6280a5123ace2886701877a0b6e30c659a109b",
   ]
 }

--- a/terraform/snowflake/environments/prd/main.tf
+++ b/terraform/snowflake/environments/prd/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "0.92"
+      version = "0.97"
     }
   }
   required_version = ">= 1.0"

--- a/terraform/snowflake/modules/database/main.tf
+++ b/terraform/snowflake/modules/database/main.tf
@@ -105,7 +105,7 @@ resource "snowflake_database" "this" {
 #            Access Roles            #
 ######################################
 
-resource "snowflake_role" "this" {
+resource "snowflake_account_role" "this" {
   provider = snowflake.useradmin
   for_each = toset(keys(local.database))
   name     = "${snowflake_database.this.name}_${each.key}"
@@ -119,7 +119,7 @@ resource "snowflake_role" "this" {
 resource "snowflake_grant_account_role" "this_to_sysadmin" {
   provider         = snowflake.useradmin
   for_each         = toset(keys(local.database))
-  role_name        = snowflake_role.this[each.key].name
+  role_name        = snowflake_account_role.this[each.key].name
   parent_role_name = "SYSADMIN"
 }
 
@@ -140,7 +140,7 @@ resource "snowflake_grant_privileges_to_account_role" "database" {
   provider          = snowflake.securityadmin
   for_each          = local.database
   privileges        = each.value
-  account_role_name = snowflake_role.this[each.key].name
+  account_role_name = snowflake_account_role.this[each.key].name
   on_account_object {
     object_type = "DATABASE"
     object_name = snowflake_database.this.name
@@ -151,7 +151,7 @@ resource "snowflake_grant_privileges_to_account_role" "database" {
 # Schema grants
 resource "snowflake_grant_ownership" "schemas" {
   provider          = snowflake.securityadmin
-  account_role_name = snowflake_role.this["READWRITECONTROL"].name
+  account_role_name = snowflake_account_role.this["READWRITECONTROL"].name
   on {
     future {
       object_type_plural = "SCHEMAS"
@@ -164,7 +164,7 @@ resource "snowflake_grant_privileges_to_account_role" "schemas" {
   provider          = snowflake.securityadmin
   for_each          = local.schema
   privileges        = each.value
-  account_role_name = snowflake_role.this[each.key].name
+  account_role_name = snowflake_account_role.this[each.key].name
   on_schema {
     future_schemas_in_database = snowflake_database.this.name
   }
@@ -175,7 +175,7 @@ resource "snowflake_grant_privileges_to_account_role" "public" {
   provider          = snowflake.securityadmin
   for_each          = local.schema
   privileges        = each.value
-  account_role_name = snowflake_role.this[each.key].name
+  account_role_name = snowflake_account_role.this[each.key].name
   on_schema {
     schema_name = "${snowflake_database.this.name}.PUBLIC"
   }
@@ -185,7 +185,7 @@ resource "snowflake_grant_privileges_to_account_role" "public" {
 # Table grants
 resource "snowflake_grant_ownership" "tables" {
   provider          = snowflake.securityadmin
-  account_role_name = snowflake_role.this["READWRITECONTROL"].name
+  account_role_name = snowflake_account_role.this["READWRITECONTROL"].name
   on {
     future {
       object_type_plural = "TABLES"
@@ -198,7 +198,7 @@ resource "snowflake_grant_privileges_to_account_role" "tables" {
   provider          = snowflake.securityadmin
   for_each          = local.table
   privileges        = each.value
-  account_role_name = snowflake_role.this[each.key].name
+  account_role_name = snowflake_account_role.this[each.key].name
   on_schema_object {
     future {
       object_type_plural = "TABLES"
@@ -211,7 +211,7 @@ resource "snowflake_grant_privileges_to_account_role" "tables" {
 # View grants
 resource "snowflake_grant_ownership" "views" {
   provider          = snowflake.securityadmin
-  account_role_name = snowflake_role.this["READWRITECONTROL"].name
+  account_role_name = snowflake_account_role.this["READWRITECONTROL"].name
   on {
     future {
       object_type_plural = "VIEWS"
@@ -224,7 +224,7 @@ resource "snowflake_grant_privileges_to_account_role" "views" {
   provider          = snowflake.securityadmin
   for_each          = local.view
   privileges        = each.value
-  account_role_name = snowflake_role.this[each.key].name
+  account_role_name = snowflake_account_role.this[each.key].name
   on_schema_object {
     future {
       object_type_plural = "VIEWS"

--- a/terraform/snowflake/modules/elt/roles.tf
+++ b/terraform/snowflake/modules/elt/roles.tf
@@ -5,7 +5,7 @@
 # The loader persona is for tools like Airflow or Fivetran, which load
 # raw data into Snowflake for later processing. It has read/write/control
 # permissions in RAW.
-resource "snowflake_role" "loader" {
+resource "snowflake_account_role" "loader" {
   provider = snowflake.useradmin
   name     = "LOADER_${var.environment}"
   comment  = "Permissions to load data to the ${module.raw.name} database"
@@ -14,7 +14,7 @@ resource "snowflake_role" "loader" {
 # The transformer persona is for in-warehouse data transformations. Most analytics
 # engineers will use this role, as will dbt robot users. It has read/write/control
 # permissions in ANALYTICS and TRANSFORM, as well as read permissions in RAW.
-resource "snowflake_role" "transformer" {
+resource "snowflake_account_role" "transformer" {
   provider = snowflake.useradmin
   name     = "TRANSFORMER_${var.environment}"
   comment  = "Permissions to read data from the ${module.raw.name} database, and read/write to ${module.transform.name} and ${module.analytics.name}"
@@ -22,7 +22,7 @@ resource "snowflake_role" "transformer" {
 
 # The reporter persona is for BI tools to consume analysis-ready tables in the
 # analytics databse. It has read permissions in ANALYTICS.
-resource "snowflake_role" "reporter" {
+resource "snowflake_account_role" "reporter" {
   provider = snowflake.useradmin
   name     = "REPORTER_${var.environment}"
   comment  = "Permissions to read data from the ${module.analytics.name} database"
@@ -30,7 +30,7 @@ resource "snowflake_role" "reporter" {
 
 # The reader persona is for CI tools to be able to reflect on the databases.
 # TODO: can we restrict the permissions for this role to just REFERENCES?
-resource "snowflake_role" "reader" {
+resource "snowflake_account_role" "reader" {
   provider = snowflake.useradmin
   name     = "READER_${var.environment}"
   comment  = "Permissions to read ${module.analytics.name}, ${module.transform.name}, and ${module.raw.name} for CI purposes"
@@ -38,7 +38,7 @@ resource "snowflake_role" "reader" {
 
 # The logger role is for logging solutions like Sentinel to introspect
 # things like usage and access.
-resource "snowflake_role" "logger" {
+resource "snowflake_account_role" "logger" {
   provider = snowflake.useradmin
   name     = "LOGGER_${var.environment}"
   comment  = "Permissions to read the SNOWFLAKE metadatabase for logging purposes"
@@ -54,25 +54,25 @@ resource "snowflake_role" "logger" {
 
 resource "snowflake_grant_account_role" "loader_to_sysadmin" {
   provider         = snowflake.useradmin
-  role_name        = snowflake_role.loader.name
+  role_name        = snowflake_account_role.loader.name
   parent_role_name = "SYSADMIN"
 }
 
 resource "snowflake_grant_account_role" "transformer_to_sysadmin" {
   provider         = snowflake.useradmin
-  role_name        = snowflake_role.transformer.name
+  role_name        = snowflake_account_role.transformer.name
   parent_role_name = "SYSADMIN"
 }
 
 resource "snowflake_grant_account_role" "reporter_to_sysadmin" {
   provider         = snowflake.useradmin
-  role_name        = snowflake_role.reporter.name
+  role_name        = snowflake_account_role.reporter.name
   parent_role_name = "SYSADMIN"
 }
 
 resource "snowflake_grant_account_role" "reader_to_sysadmin" {
   provider         = snowflake.useradmin
-  role_name        = snowflake_role.reader.name
+  role_name        = snowflake_account_role.reader.name
   parent_role_name = "SYSADMIN"
 }
 
@@ -80,7 +80,7 @@ resource "snowflake_grant_account_role" "reader_to_sysadmin" {
 # directly to accountadmin
 resource "snowflake_grant_account_role" "logger_to_accountadmin" {
   provider         = snowflake.accountadmin
-  role_name        = snowflake_role.logger.name
+  role_name        = snowflake_account_role.logger.name
   parent_role_name = "ACCOUNTADMIN"
 }
 
@@ -88,35 +88,35 @@ resource "snowflake_grant_account_role" "logger_to_accountadmin" {
 resource "snowflake_grant_account_role" "raw_rwc_to_loader" {
   provider         = snowflake.useradmin
   role_name        = "${module.raw.name}_READWRITECONTROL"
-  parent_role_name = snowflake_role.loader.name
+  parent_role_name = snowflake_account_role.loader.name
 }
 
 # Reporter has read privileges in ANALYTICS
 resource "snowflake_grant_account_role" "analytics_r_to_reporter" {
   provider         = snowflake.useradmin
   role_name        = "${module.analytics.name}_READ"
-  parent_role_name = snowflake_role.reporter.name
+  parent_role_name = snowflake_account_role.reporter.name
 }
 
 # Transformer has RWC privileges in TRANSFORM
 resource "snowflake_grant_account_role" "transform_rwc_to_transformer" {
   provider         = snowflake.useradmin
   role_name        = "${module.transform.name}_READWRITECONTROL"
-  parent_role_name = snowflake_role.transformer.name
+  parent_role_name = snowflake_account_role.transformer.name
 }
 
 # Transformer has RWC privileges in ANALYTICS
 resource "snowflake_grant_account_role" "analytics_rwc_to_transformer" {
   provider         = snowflake.useradmin
   role_name        = "${module.analytics.name}_READWRITECONTROL"
-  parent_role_name = snowflake_role.transformer.name
+  parent_role_name = snowflake_account_role.transformer.name
 }
 
 # Transformer has read permissions in RAW
 resource "snowflake_grant_account_role" "raw_r_to_transformer" {
   provider         = snowflake.useradmin
   role_name        = "${module.raw.name}_READ"
-  parent_role_name = snowflake_role.transformer.name
+  parent_role_name = snowflake_account_role.transformer.name
 }
 
 # Transformer can use the TRANSFORMING warehouse
@@ -124,7 +124,7 @@ resource "snowflake_grant_account_role" "transforming_to_transformer" {
   provider         = snowflake.useradmin
   for_each         = toset(values(module.transforming)[*].access_role_name)
   role_name        = each.key
-  parent_role_name = snowflake_role.transformer.name
+  parent_role_name = snowflake_account_role.transformer.name
 }
 
 # Reporter can use the REPORTING warehouse
@@ -132,7 +132,7 @@ resource "snowflake_grant_account_role" "reporting_to_reporter" {
   provider         = snowflake.useradmin
   for_each         = toset(values(module.reporting)[*].access_role_name)
   role_name        = each.key
-  parent_role_name = snowflake_role.reporter.name
+  parent_role_name = snowflake_account_role.reporter.name
 }
 
 # Loader can use the LOADING warehouse
@@ -140,28 +140,28 @@ resource "snowflake_grant_account_role" "loading_to_loader" {
   provider         = snowflake.useradmin
   for_each         = toset(values(module.loading)[*].access_role_name)
   role_name        = each.key
-  parent_role_name = snowflake_role.loader.name
+  parent_role_name = snowflake_account_role.loader.name
 }
 
 # Reader has read permissions in RAW
 resource "snowflake_grant_account_role" "raw_r_to_reader" {
   provider         = snowflake.useradmin
   role_name        = "${module.raw.name}_READ"
-  parent_role_name = snowflake_role.reader.name
+  parent_role_name = snowflake_account_role.reader.name
 }
 
 # Reader has read permissions in TRANSFORM
 resource "snowflake_grant_account_role" "transform_r_to_reader" {
   provider         = snowflake.useradmin
   role_name        = "${module.transform.name}_READ"
-  parent_role_name = snowflake_role.reader.name
+  parent_role_name = snowflake_account_role.reader.name
 }
 
 # Reader has read permissions in ANALYTICS
 resource "snowflake_grant_account_role" "analytics_r_to_reader" {
   provider         = snowflake.useradmin
   role_name        = "${module.analytics.name}_READ"
-  parent_role_name = snowflake_role.reader.name
+  parent_role_name = snowflake_account_role.reader.name
 }
 
 # Reader can use the REPORTING warehouse
@@ -169,14 +169,14 @@ resource "snowflake_grant_account_role" "reporting_to_reader" {
   provider         = snowflake.useradmin
   for_each         = toset(values(module.reporting)[*].access_role_name)
   role_name        = each.key
-  parent_role_name = snowflake_role.reader.name
+  parent_role_name = snowflake_account_role.reader.name
 }
 
 # Logger can use the LOGGING warehouse
 resource "snowflake_grant_account_role" "logging_to_logger" {
   provider         = snowflake.useradmin
   role_name        = module.logging.access_role_name
-  parent_role_name = snowflake_role.logger.name
+  parent_role_name = snowflake_account_role.logger.name
 }
 
 ######################################
@@ -186,7 +186,7 @@ resource "snowflake_grant_account_role" "logging_to_logger" {
 # Imported privileges for logging
 resource "snowflake_grant_privileges_to_account_role" "imported_privileges_to_logger" {
   provider          = snowflake.accountadmin
-  account_role_name = snowflake_role.logger.name
+  account_role_name = snowflake_account_role.logger.name
   privileges        = ["IMPORTED PRIVILEGES"]
   on_account_object {
     object_type = "DATABASE"

--- a/terraform/snowflake/modules/elt/users.tf
+++ b/terraform/snowflake/modules/elt/users.tf
@@ -6,6 +6,9 @@ resource "snowflake_user" "dbt" {
   provider = snowflake.useradmin
   name     = "DBT_CLOUD_SVC_USER_${var.environment}"
   comment  = "Service user for dbt Cloud"
+  lifecycle {
+    ignore_changes = [rsa_public_key]
+  }
 
   default_warehouse = module.transforming["XS"].name
   default_role      = snowflake_account_role.transformer.name
@@ -18,6 +21,9 @@ resource "snowflake_user" "airflow" {
   provider = snowflake.useradmin
   name     = "MWAA_SVC_USER_${var.environment}"
   comment  = "Service user for Airflow"
+  lifecycle {
+    ignore_changes = [rsa_public_key]
+  }
 
   default_warehouse = module.loading["XS"].name
   default_role      = snowflake_account_role.loader.name
@@ -29,6 +35,9 @@ resource "snowflake_user" "fivetran" {
   provider = snowflake.useradmin
   name     = "FIVETRAN_SVC_USER_${var.environment}"
   comment  = "Service user for Fivetran"
+  lifecycle {
+    ignore_changes = [rsa_public_key]
+  }
 
   default_warehouse = module.loading["XS"].name
   default_role      = snowflake_account_role.loader.name
@@ -40,6 +49,9 @@ resource "snowflake_user" "github_ci" {
   provider = snowflake.useradmin
   name     = "GITHUB_ACTIONS_SVC_USER_${var.environment}"
   comment  = "Service user for GitHub CI"
+  lifecycle {
+    ignore_changes = [rsa_public_key]
+  }
 
   default_warehouse = module.reporting["XS"].name
   default_role      = snowflake_account_role.reader.name
@@ -51,6 +63,9 @@ resource "snowflake_user" "sentinel" {
   provider = snowflake.useradmin
   name     = "SENTINEL_SVC_USER_${var.environment}"
   comment  = "Service user for Sentinel"
+  lifecycle {
+    ignore_changes = [rsa_public_key]
+  }
 
   default_warehouse = module.logging.name
   default_role      = snowflake_account_role.logger.name

--- a/terraform/snowflake/modules/elt/users.tf
+++ b/terraform/snowflake/modules/elt/users.tf
@@ -8,7 +8,7 @@ resource "snowflake_user" "dbt" {
   comment  = "Service user for dbt Cloud"
 
   default_warehouse = module.transforming["XS"].name
-  default_role      = snowflake_role.transformer.name
+  default_role      = snowflake_account_role.transformer.name
 
   must_change_password = false
 }
@@ -20,7 +20,7 @@ resource "snowflake_user" "airflow" {
   comment  = "Service user for Airflow"
 
   default_warehouse = module.loading["XS"].name
-  default_role      = snowflake_role.loader.name
+  default_role      = snowflake_account_role.loader.name
 
   must_change_password = false
 }
@@ -31,7 +31,7 @@ resource "snowflake_user" "fivetran" {
   comment  = "Service user for Fivetran"
 
   default_warehouse = module.loading["XS"].name
-  default_role      = snowflake_role.loader.name
+  default_role      = snowflake_account_role.loader.name
 
   must_change_password = false
 }
@@ -42,7 +42,7 @@ resource "snowflake_user" "github_ci" {
   comment  = "Service user for GitHub CI"
 
   default_warehouse = module.reporting["XS"].name
-  default_role      = snowflake_role.reader.name
+  default_role      = snowflake_account_role.reader.name
 
   must_change_password = false
 }
@@ -53,7 +53,7 @@ resource "snowflake_user" "sentinel" {
   comment  = "Service user for Sentinel"
 
   default_warehouse = module.logging.name
-  default_role      = snowflake_role.logger.name
+  default_role      = snowflake_account_role.logger.name
 
   must_change_password = false
 }
@@ -64,30 +64,30 @@ resource "snowflake_user" "sentinel" {
 
 resource "snowflake_grant_account_role" "transformer_to_dbt" {
   provider  = snowflake.useradmin
-  role_name = snowflake_role.transformer.name
+  role_name = snowflake_account_role.transformer.name
   user_name = snowflake_user.dbt.name
 }
 
 resource "snowflake_grant_account_role" "loader_to_airflow" {
   provider  = snowflake.useradmin
-  role_name = snowflake_role.loader.name
+  role_name = snowflake_account_role.loader.name
   user_name = snowflake_user.airflow.name
 }
 
 resource "snowflake_grant_account_role" "loader_to_fivetran" {
   provider  = snowflake.useradmin
-  role_name = snowflake_role.loader.name
+  role_name = snowflake_account_role.loader.name
   user_name = snowflake_user.fivetran.name
 }
 
 resource "snowflake_grant_account_role" "reader_to_github_ci" {
   provider  = snowflake.useradmin
-  role_name = snowflake_role.reader.name
+  role_name = snowflake_account_role.reader.name
   user_name = snowflake_user.github_ci.name
 }
 
 resource "snowflake_grant_account_role" "logger_to_sentinel" {
   provider  = snowflake.useradmin
-  role_name = snowflake_role.logger.name
+  role_name = snowflake_account_role.logger.name
   user_name = snowflake_user.sentinel.name
 }

--- a/terraform/snowflake/modules/warehouse/main.tf
+++ b/terraform/snowflake/modules/warehouse/main.tf
@@ -50,7 +50,7 @@ resource "snowflake_warehouse" "this" {
 #################################
 
 # Monitoring, usage, and operating permissions for the LOADING warehouse.
-resource "snowflake_role" "this" {
+resource "snowflake_account_role" "this" {
   name     = "${var.name}_WH_MOU"
   provider = snowflake.useradmin
   comment  = "Monitoring, usage, and operating permissions for the ${var.name} warehouse"
@@ -62,7 +62,7 @@ resource "snowflake_role" "this" {
 
 resource "snowflake_grant_account_role" "this_to_sysadmin" {
   provider         = snowflake.useradmin
-  role_name        = snowflake_role.this.name
+  role_name        = snowflake_account_role.this.name
   parent_role_name = "SYSADMIN"
 }
 
@@ -73,7 +73,7 @@ resource "snowflake_grant_account_role" "this_to_sysadmin" {
 resource "snowflake_grant_privileges_to_account_role" "this" {
   provider          = snowflake.securityadmin
   privileges        = local.warehouse.MOU
-  account_role_name = snowflake_role.this.name
+  account_role_name = snowflake_account_role.this.name
   on_account_object {
     object_type = "WAREHOUSE"
     object_name = snowflake_warehouse.this.name

--- a/terraform/snowflake/modules/warehouse/outputs.tf
+++ b/terraform/snowflake/modules/warehouse/outputs.tf
@@ -1,6 +1,6 @@
 output "access_role_name" {
   description = "Warehouse access_role"
-  value       = snowflake_role.this.name
+  value       = snowflake_account_role.this.name
 }
 
 output "name" {


### PR DESCRIPTION
After the initial setup and validation, the main change needed was to change snowflake_role to snowflake_account_role. 
Here is the partial output from terraform plan, Please review it and share your feedback.

****************************************************

  # module.elt.module.transforming["XL"].snowflake_warehouse.this will be updated in-place
  ~ resource "snowflake_warehouse" "this" {
      ~ enable_query_acceleration           = "false" -> "default"
        id                                  = "TRANSFORMING_XL_DEV"
      - max_cluster_count                   = 1 -> null
      ~ max_concurrency_level               = 8 -> (known after apply)
      - min_cluster_count                   = 1 -> null
        name                                = "TRANSFORMING_XL_DEV"
      ~ query_acceleration_max_scale_factor = 8 -> -1
      - scaling_policy                      = "STANDARD" -> null
      ~ show_output                         = [
          - {
              - auto_resume                         = true
              - auto_suspend                        = 300
              - available                           = 0
              - comment                             = "Primary warehouse for transforming data. Analytics engineers and automated transformation tools should use this warehouse"
              - created_on                          = "2023-05-25 15:24:30.262 -0700 PDT"
              - enable_query_acceleration           = false
              - is_current                          = false
              - is_default                          = false
              - max_cluster_count                   = 1
              - min_cluster_count                   = 1
              - name                                = "TRANSFORMING_XL_DEV"
              - other                               = 0
              - owner                               = "SYSADMIN"
              - owner_role_type                     = "ROLE"
              - provisioning                        = 0
              - query_acceleration_max_scale_factor = 8
              - queued                              = 0
              - quiescing                           = 0
              - resumed_on                          = "2024-05-02 12:02:40.752 -0700 PDT"
              - running                             = 0
              - scaling_policy                      = "STANDARD"
              - size                                = "XLARGE"
              - started_clusters                    = 0
              - state                               = "SUSPENDED"
              - type                                = "STANDARD"
              - updated_on                          = "2024-05-02 12:02:40.752 -0700 PDT"
                # (1 unchanged attribute hidden)
            },
        ] -> (known after apply)
      ~ statement_timeout_in_seconds        = 172800 -> (known after apply)
      - warehouse_type                      = "STANDARD" -> null
        # (8 unchanged attributes hidden)
    }

  # module.elt.module.transforming["XS"].snowflake_account_role.this will be created
  + resource "snowflake_account_role" "this" {
      + comment              = "Monitoring, usage, and operating permissions for the TRANSFORMING_XS_DEV warehouse"
      + fully_qualified_name = (known after apply)
      + id                   = (known after apply)
      + name                 = "TRANSFORMING_XS_DEV_WH_MOU"
      + show_output          = (known after apply)
    }

  # module.elt.module.transforming["XS"].snowflake_role.this will be destroyed
  # (because snowflake_role.this is not in configuration)
  - resource "snowflake_role" "this" {
      - comment = "Monitoring, usage, and operating permissions for the TRANSFORMING_XS_DEV warehouse" -> null
      - id      = "TRANSFORMING_XS_DEV_WH_MOU" -> null
      - name    = "TRANSFORMING_XS_DEV_WH_MOU" -> null
    }

  # module.elt.module.transforming["XS"].snowflake_warehouse.this will be updated in-place
  ~ resource "snowflake_warehouse" "this" {
      ~ enable_query_acceleration           = "false" -> "default"
        id                                  = "TRANSFORMING_XS_DEV"
      - max_cluster_count                   = 1 -> null
      ~ max_concurrency_level               = 8 -> (known after apply)
      - min_cluster_count                   = 1 -> null
        name                                = "TRANSFORMING_XS_DEV"
      ~ query_acceleration_max_scale_factor = 8 -> -1
      - scaling_policy                      = "STANDARD" -> null
      ~ show_output                         = [
          - {
              - auto_resume                         = true
              - auto_suspend                        = 300
              - available                           = 0
              - comment                             = "Primary warehouse for transforming data. Analytics engineers and automated transformation tools should use this warehouse"
              - created_on                          = "2023-05-25 15:24:29.68 -0700 PDT"
              - enable_query_acceleration           = false
              - is_current                          = false
              - is_default                          = false
              - max_cluster_count                   = 1
              - min_cluster_count                   = 1
              - name                                = "TRANSFORMING_XS_DEV"
              - other                               = 0
              - owner                               = "SYSADMIN"
              - owner_role_type                     = "ROLE"
              - provisioning                        = 0
              - query_acceleration_max_scale_factor = 8
              - queued                              = 0
              - quiescing                           = 0
              - resumed_on                          = "2024-10-11 16:25:43.207 -0700 PDT"
              - running                             = 0
              - scaling_policy                      = "STANDARD"
              - size                                = "XSMALL"
              - started_clusters                    = 0
              - state                               = "SUSPENDED"
              - type                                = "STANDARD"
              - updated_on                          = "2024-10-11 16:25:43.207 -0700 PDT"
                # (1 unchanged attribute hidden)
            },
        ] -> (known after apply)
      ~ statement_timeout_in_seconds        = 172800 -> (known after apply)
      - warehouse_type                      = "STANDARD" -> null
        # (8 unchanged attributes hidden)
    }

Plan: 24 to add, 20 to change, 24 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
(infra) ram.kishore@180 dev % 

******************************************************
