### PR TITLE
Rework warehouse `for_each` statements

### DIFF
--- a/terraform/snowflake/modules/elt/roles.tf
+++ b/terraform/snowflake/modules/elt/roles.tf
@@ -122,24 +122,24 @@ resource "snowflake_grant_account_role" "raw_r_to_transformer" {
 # Transformer can use the TRANSFORMING warehouse
 resource "snowflake_grant_account_role" "transforming_to_transformer" {
   provider         = snowflake.useradmin
-  for_each         = toset(values(module.transforming)[*].access_role_name)
-  role_name        = each.key
+  for_each         = toset(values(local.sizes))
+  role_name        = module.transforming[each.key].access_role_name
   parent_role_name = snowflake_account_role.transformer.name
 }
 
 # Reporter can use the REPORTING warehouse
 resource "snowflake_grant_account_role" "reporting_to_reporter" {
   provider         = snowflake.useradmin
-  for_each         = toset(values(module.reporting)[*].access_role_name)
-  role_name        = each.key
+  for_each         = toset(values(local.sizes))
+  role_name        = module.reporting[each.key].access_role_name
   parent_role_name = snowflake_account_role.reporter.name
 }
 
 # Loader can use the LOADING warehouse
 resource "snowflake_grant_account_role" "loading_to_loader" {
   provider         = snowflake.useradmin
-  for_each         = toset(values(module.loading)[*].access_role_name)
-  role_name        = each.key
+  for_each         = toset(values(local.sizes))
+  role_name        = module.loading[each.key].access_role_name
   parent_role_name = snowflake_account_role.loader.name
 }
 
@@ -167,8 +167,8 @@ resource "snowflake_grant_account_role" "analytics_r_to_reader" {
 # Reader can use the REPORTING warehouse
 resource "snowflake_grant_account_role" "reporting_to_reader" {
   provider         = snowflake.useradmin
-  for_each         = toset(values(module.reporting)[*].access_role_name)
-  role_name        = each.key
+  for_each         = toset(values(local.sizes))
+  role_name        = module.reporting[each.key].access_role_name
   parent_role_name = snowflake_account_role.reader.name
 }
 

--- a/terraform/snowflake/modules/elt/roles.tf
+++ b/terraform/snowflake/modules/elt/roles.tf
@@ -122,7 +122,7 @@ resource "snowflake_grant_account_role" "raw_r_to_transformer" {
 # Transformer can use the TRANSFORMING warehouse
 resource "snowflake_grant_account_role" "transforming_to_transformer" {
   provider         = snowflake.useradmin
-  for_each         = toset(values(local.sizes))
+  for_each         = toset(keys(local.sizes))
   role_name        = module.transforming[each.key].access_role_name
   parent_role_name = snowflake_account_role.transformer.name
 }
@@ -130,7 +130,7 @@ resource "snowflake_grant_account_role" "transforming_to_transformer" {
 # Reporter can use the REPORTING warehouse
 resource "snowflake_grant_account_role" "reporting_to_reporter" {
   provider         = snowflake.useradmin
-  for_each         = toset(values(local.sizes))
+  for_each         = toset(keys(local.sizes))
   role_name        = module.reporting[each.key].access_role_name
   parent_role_name = snowflake_account_role.reporter.name
 }
@@ -138,7 +138,7 @@ resource "snowflake_grant_account_role" "reporting_to_reporter" {
 # Loader can use the LOADING warehouse
 resource "snowflake_grant_account_role" "loading_to_loader" {
   provider         = snowflake.useradmin
-  for_each         = toset(values(local.sizes))
+  for_each         = toset(keys(local.sizes))
   role_name        = module.loading[each.key].access_role_name
   parent_role_name = snowflake_account_role.loader.name
 }
@@ -167,7 +167,7 @@ resource "snowflake_grant_account_role" "analytics_r_to_reader" {
 # Reader can use the REPORTING warehouse
 resource "snowflake_grant_account_role" "reporting_to_reader" {
   provider         = snowflake.useradmin
-  for_each         = toset(values(local.sizes))
+  for_each         = toset(keys(local.sizes))
   role_name        = module.reporting[each.key].access_role_name
   parent_role_name = snowflake_account_role.reader.name
 }


### PR DESCRIPTION
Follow-up to #413 

The existing `for_each` construction wound up causing problems because terraform was unable to statically determine the keys for the for loop (I guess the expression was just a bit too complex, some more discussion [here](https://discuss.hashicorp.com/t/invalid-for-each-argument-during-import/55332/6)).

This PR simplifies the `for_each` statements a bit which seems to resolve the problem. The actual content of the configuration does not change, though the grants need to be recreated since they have different names (this has less impact than recreating roles).