### PR TITLE
Update URLs to their new home

### DIFF
--- a/jobs/geo/load_global_ml_building_footprints.py
+++ b/jobs/geo/load_global_ml_building_footprints.py
@@ -17,7 +17,7 @@ def load_state_footprints(conn) -> None:
 
     print("Identifying California quadkeys")
     df = pandas.read_csv(
-        "https://minedbuildings.blob.core.windows.net/global-buildings/dataset-links.csv",
+        "https://minedbuildings.z5.web.core.windows.net/global-buildings/dataset-links.csv",
         dtype={"QuadKey": "str"},  # Don't use an int, since there are leading zeros!
     )
 
@@ -42,7 +42,7 @@ def load_state_footprints(conn) -> None:
         )
 
     # As a second pass, prune out the tiles which don't actually intersect California
-    quadkeys = geopandas.GeoDataFrame.from_records(features)
+    quadkeys = geopandas.GeoDataFrame.from_records(features).set_geometry("geometry")
     california_quadkeys = quadkeys[quadkeys.intersects(california)]
 
     # Now get a list of all the URLs which have a quadkey intersecting California

--- a/jobs/geo/load_us_building_footprints.py
+++ b/jobs/geo/load_us_building_footprints.py
@@ -9,7 +9,7 @@ def load_state_footprints(conn) -> None:
 
     print("Downloading data")
     gdf = geopandas.read_file(
-        "https://usbuildingdata.blob.core.windows.net/usbuildings-v2/California.geojson.zip"
+        "https://minedbuildings.z5.web.core.windows.net/legacy/usbuildings-v2/California.geojson.zip"
     )
 
     print("Writing data to snowflake")

--- a/jobs/utils/snowflake.py
+++ b/jobs/utils/snowflake.py
@@ -46,6 +46,7 @@ def snowflake_connection_from_environment(**kwargs):
     # Required parameters
     account = os.environ["SNOWFLAKE_ACCOUNT"]
     user = os.environ["SNOWFLAKE_USER"]
+    authenticator = os.environ.get("SNOWFLAKE_AUTHENTICATOR")
 
     # Optional parameters
     warehouse = os.environ.get("SNOWFLAKE_WAREHOUSE")
@@ -66,6 +67,7 @@ def snowflake_connection_from_environment(**kwargs):
         "database": database,
         "schema": schema,
         "role": role,
+        "authenticator": authenticator,
     }
 
     # Check that there is only one authentication mechanism implied between


### PR DESCRIPTION
Fixes #434 

Interestingly, the US Building Footprints URLs now have "legacy" in them, a seeming confirmation of what we suspected about the future of that dataset.