### PR TITLE
Inital default password policy changes

### DIFF
--- a/terraform/snowflake/environments/dev/main.tf
+++ b/terraform/snowflake/environments/dev/main.tf
@@ -42,6 +42,7 @@ provider "snowflake" {
   account_name      = var.account_name
   organization_name = var.organization_name
   role    = "PUBLIC"
+  preview_features_enabled = ["snowflake_authentication_policy_resource", "snowflake_password_policy_resource"]
 }
 
 # Snowflake provider for account administration (to be used only when necessary).
@@ -50,6 +51,7 @@ provider "snowflake" {
   role    = "ACCOUNTADMIN"
   account_name      = var.account_name
   organization_name = var.organization_name
+  preview_features_enabled = ["snowflake_authentication_policy_resource", "snowflake_password_policy_resource"]
 }
 
 # Snowflake provider for creating databases, warehouses, etc.
@@ -58,6 +60,7 @@ provider "snowflake" {
   role    = "SYSADMIN"
   account_name      = var.account_name
   organization_name = var.organization_name
+  preview_features_enabled = ["snowflake_authentication_policy_resource", "snowflake_password_policy_resource"]
 }
 
 # Snowflake provider for managing grants to roles.
@@ -66,6 +69,7 @@ provider "snowflake" {
   role    = "SECURITYADMIN"
   account_name      = var.account_name
   organization_name = var.organization_name
+  preview_features_enabled = ["snowflake_authentication_policy_resource", "snowflake_password_policy_resource"]
 }
 
 # Snowflake provider for managing user accounts and roles.
@@ -74,6 +78,7 @@ provider "snowflake" {
   role    = "USERADMIN"
   account_name      = var.account_name
   organization_name = var.organization_name
+  preview_features_enabled = ["snowflake_authentication_policy_resource", "snowflake_password_policy_resource"]
 }
 
 ############################
@@ -103,4 +108,26 @@ resource "snowflake_grant_account_role" "logger_to_transformer" {
   provider         = snowflake.useradmin
   role_name        = "LOGGER_${var.environment}"
   parent_role_name = "TRANSFORMER_${var.environment}"
+}
+
+# Default user password policy
+resource "snowflake_password_policy" "user_password_policy" {
+  database             = "POLICIES" # Database name
+  schema               = "PUBLIC"   # Schema name
+  name                 = "user_password_policy"
+  min_length           = 14
+  min_upper_case_chars = 1
+  min_lower_case_chars = 1
+  min_numeric_chars    = 1
+  min_special_chars    = 1
+  max_retries          = 5
+  lockout_time_mins    = 30
+  history              = 5
+  max_age_days         = 60
+  or_replace           = true # Ensures the policy can be updated without errors
+}
+
+# Set the default password policy for the account
+resource "snowflake_account_password_policy_attachment" "attachment" {
+  password_policy = snowflake_password_policy.user_password_policy.fully_qualified_name
 }


### PR DESCRIPTION
Can you please review the changes and share your feedback ?

The changes include 

1. Defining a default password policy
2. Attaching it to the account

Also I could not convert the grant below into terraform script. I do not think this a blocker and it is not critical.
May be I am missing something. I thought it should be simple to do this. But in the current documentation, I did not see an option available to do this in tf.

 -- GRANT USAGE ON PASSWORD POLICY user_password_policy TO ROLE securityadmin; ---

Looking at the plan looks like the service account are getting impacted, please refer to the attached plan.
I am concerned about the changes to service account password that would be needed.