### PR TITLE
Enabled missing preview features

### DIFF
--- a/terraform/snowflake/environments/prd/main.tf
+++ b/terraform/snowflake/environments/prd/main.tf
@@ -56,7 +56,7 @@ provider "snowflake" {
   role    = "ACCOUNTADMIN"
   account_name      = var.account_name
   organization_name = var.organization_name
-  preview_features_enabled = ["snowflake_authentication_policy_resource", "snowflake_password_policy_resource"]
+  preview_features_enabled = ["snowflake_authentication_policy_resource", "snowflake_password_policy_resource", "snowflake_account_password_policy_attachment_resource", "snowflake_account_authentication_policy_attachment_resource"]
 }
 
 # Snowflake provider for creating databases, warehouses, etc.
@@ -73,7 +73,7 @@ provider "snowflake" {
   role    = "SECURITYADMIN"
   account_name      = var.account_name
   organization_name = var.organization_name
-  preview_features_enabled = ["snowflake_authentication_policy_resource", "snowflake_password_policy_resource"]
+  preview_features_enabled = ["snowflake_authentication_policy_resource", "snowflake_password_policy_resource", "snowflake_account_password_policy_attachment_resource","snowflake_account_authentication_policy_attachment_resource"]
 }
 
 # Snowflake provider for managing user accounts and roles.


### PR DESCRIPTION
Can you please review the change and let me know your feedback ?

It looks like all the authentication policies and password have all been added already. So the latest plan only shows two changes below.

*****************************************************************
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # snowflake_account_authentication_policy_attachment.default_policy[0] will be created
  + resource "snowflake_account_authentication_policy_attachment" "default_policy" {
      + authentication_policy = "\"POLICIES\".\"PUBLIC\".\"odi_okta_only\""
      + id                    = (known after apply)
    }

  # snowflake_account_password_policy_attachment.attachment will be created
  + resource "snowflake_account_password_policy_attachment" "attachment" {
      + id              = (known after apply)
      + password_policy = "\"POLICIES\".\"PUBLIC\".\"user_password_policy\""
    }

Plan: 2 to add, 0 to change, 0 to destroy.


*****************************************************************