### PR TITLE
Updates to resolve issues encountered during the apply phase

### DIFF
--- a/terraform/snowflake/modules/elt/roles.tf
+++ b/terraform/snowflake/modules/elt/roles.tf
@@ -45,10 +45,10 @@ resource "snowflake_account_role" "logger" {
 }
 
 # Adding streamlit role - only for analytics database
-resource "snowflake_account_role" "streamlit_analytics" {
+resource "snowflake_account_role" "streamlit_access_role" {
   provider = snowflake.useradmin
-  name     = "${module.analytics.name}_STREAMLIT"
-  comment  = "Permissions to create Streamlit applications and stages in the ${module.analytics.name} database for the ${var.environment} environment."
+  name     = "${module.analytics.name}_STREAMLIT_ACCESS" # Name of the role
+  comment  = "Role to grant Streamlit creation privileges"
 }
 
 ######################################
@@ -207,7 +207,6 @@ resource "snowflake_grant_privileges_to_account_role" "imported_privileges_to_lo
 # More backgorund information related to this is found
 # here - https://github.com/cagov/data-infrastructure/issues/274
 ##############################################################
-
 resource "snowflake_grant_account_role" "transform_read_to_analytics_rwc" {
   provider         = snowflake.useradmin
   role_name        = "${module.transform.name}_READ"
@@ -218,23 +217,46 @@ resource "snowflake_grant_account_role" "transform_read_to_analytics_rwc" {
 # The cross-environment grant of the ${module.raw.name}_${var.environment}_STREAMLIT role
 # to the REPORTER_DEV role will handled outside of this Terraform configuration.
 # via manual SQL execution
-resource "snowflake_grant_account_role" "streamlit_analytics_to_reporter" {
-  provider         = snowflake.useradmin
-  role_name        = snowflake_account_role.streamlit_analytics.name
-  parent_role_name = snowflake_account_role.reporter.name
+
+# Grant the Streamlit access role to the REPORTER role
+resource "snowflake_grant_account_role" "streamlit_to_reporter" {
+  provider            = snowflake.useradmin
+  role_name           = snowflake_account_role.streamlit_access_role.name
+  parent_role_name    = snowflake_account_role.reporter.name # reporter role
 }
 
-resource "snowflake_grant_privileges_to_account_role" "streamlit_database_privileges" {
-  account_role_name = snowflake_account_role.streamlit_analytics.name
-  privileges        = ["CREATE STAGE"]
-  on_account_object {
-    object_name = module.analytics.name
-    object_type = "DATABASE"
+# Grant CREATE STREAMLIT privilege on future schemas in the database to the Streamlit access role
+resource "snowflake_grant_privileges_to_account_role" "streamlit_future_streamlit_privileges" {
+  account_role_name = snowflake_account_role.streamlit_access_role.name
+  privileges        = ["CREATE STREAMLIT"]
+  on_schema {
+    future_schemas_in_database = module.analytics.name
   }
 }
 
-resource "snowflake_grant_privileges_to_account_role" "streamlit_account_privileges" {
-  account_role_name = snowflake_account_role.streamlit_analytics.name
+# Grant CREATE STREAMLIT privilege on the PUBLIC schema in the database to the Streamlit access role
+resource "snowflake_grant_privileges_to_account_role" "streamlit_public_streamlit_privileges" {
+  account_role_name = snowflake_account_role.streamlit_access_role.name
   privileges        = ["CREATE STREAMLIT"]
-  on_account        = true
+  on_schema {
+    schema_name = "${module.analytics.name}.PUBLIC"
+  }
+}
+
+# Grant CREATE STAGE privilege on future schemas in the database to the Streamlit access role
+resource "snowflake_grant_privileges_to_account_role" "streamlit_future_stage_privileges" {
+  account_role_name = snowflake_account_role.streamlit_access_role.name
+  privileges        = ["CREATE STAGE"]
+  on_schema {
+    future_schemas_in_database = module.analytics.name
+  }
+}
+
+# Grant CREATE STAGE privilege on the PUBLIC schema in the database to the Streamlit access role
+resource "snowflake_grant_privileges_to_account_role" "streamlit_public_stage_privileges" {
+  account_role_name = snowflake_account_role.streamlit_access_role.name
+  privileges        = ["CREATE STAGE"]
+  on_schema {
+    schema_name = "${module.analytics.name}.PUBLIC"
+  }
 }

--- a/terraform/snowflake/modules/elt/roles.tf
+++ b/terraform/snowflake/modules/elt/roles.tf
@@ -228,7 +228,7 @@ resource "snowflake_grant_privileges_to_account_role" "streamlit_database_privil
   account_role_name = "${module.analytics.name}_STREAMLIT"
   privileges        = ["CREATE STAGE"]
   on_account_object {
-    object_name = "${module.analytics.name}"
+    object_name = "ANALYTICS_PRD"
     object_type = "DATABASE"
   }
 }

--- a/terraform/snowflake/modules/elt/roles.tf
+++ b/terraform/snowflake/modules/elt/roles.tf
@@ -225,37 +225,19 @@ resource "snowflake_grant_account_role" "streamlit_to_reporter" {
   parent_role_name    = snowflake_account_role.reporter.name # reporter role
 }
 
-# Grant CREATE STREAMLIT privilege on future schemas in the database to the Streamlit access role
+# Grant CREATE STREAMLIT & CREATE STAGE privileges on future schemas in the database to the Streamlit access role
 resource "snowflake_grant_privileges_to_account_role" "streamlit_future_streamlit_privileges" {
   account_role_name = snowflake_account_role.streamlit_access_role.name
-  privileges        = ["CREATE STREAMLIT"]
+  privileges        = ["CREATE STREAMLIT", "CREATE STAGE"]
   on_schema {
     future_schemas_in_database = module.analytics.name
   }
 }
 
-# Grant CREATE STREAMLIT privilege on the PUBLIC schema in the database to the Streamlit access role
+# Grant CREATE STREAMLIT & CREATE STAGE privileges on the PUBLIC schema in the database to the Streamlit access role
 resource "snowflake_grant_privileges_to_account_role" "streamlit_public_streamlit_privileges" {
   account_role_name = snowflake_account_role.streamlit_access_role.name
-  privileges        = ["CREATE STREAMLIT"]
-  on_schema {
-    schema_name = "${module.analytics.name}.PUBLIC"
-  }
-}
-
-# Grant CREATE STAGE privilege on future schemas in the database to the Streamlit access role
-resource "snowflake_grant_privileges_to_account_role" "streamlit_future_stage_privileges" {
-  account_role_name = snowflake_account_role.streamlit_access_role.name
-  privileges        = ["CREATE STAGE"]
-  on_schema {
-    future_schemas_in_database = module.analytics.name
-  }
-}
-
-# Grant CREATE STAGE privilege on the PUBLIC schema in the database to the Streamlit access role
-resource "snowflake_grant_privileges_to_account_role" "streamlit_public_stage_privileges" {
-  account_role_name = snowflake_account_role.streamlit_access_role.name
-  privileges        = ["CREATE STAGE"]
+  privileges        = ["CREATE STREAMLIT", "CREATE STAGE"]
   on_schema {
     schema_name = "${module.analytics.name}.PUBLIC"
   }

--- a/terraform/snowflake/modules/elt/roles.tf
+++ b/terraform/snowflake/modules/elt/roles.tf
@@ -225,7 +225,7 @@ resource "snowflake_grant_account_role" "streamlit_analytics_to_reporter" {
 }
 
 resource "snowflake_grant_privileges_to_account_role" "streamlit_database_privileges" {
-  account_role_name = "${module.analytics.name}_STREAMLIT"
+  account_role_name = snowflake_account_role.streamlit_analytics.name
   privileges        = ["CREATE STAGE"]
   on_account_object {
     object_name = module.analytics.name
@@ -234,7 +234,7 @@ resource "snowflake_grant_privileges_to_account_role" "streamlit_database_privil
 }
 
 resource "snowflake_grant_privileges_to_account_role" "streamlit_account_privileges" {
-  account_role_name = "${module.analytics.name}_STREAMLIT"
+  account_role_name = snowflake_account_role.streamlit_analytics.name
   privileges        = ["CREATE STREAMLIT"]
   on_account        = true
 }

--- a/terraform/snowflake/modules/elt/roles.tf
+++ b/terraform/snowflake/modules/elt/roles.tf
@@ -228,7 +228,7 @@ resource "snowflake_grant_privileges_to_account_role" "streamlit_database_privil
   account_role_name = "${module.analytics.name}_STREAMLIT"
   privileges        = ["CREATE STAGE"]
   on_account_object {
-    object_name = "ANALYTICS_PRD"
+    object_name = module.analytics.name
     object_type = "DATABASE"
   }
 }

--- a/terraform/snowflake/modules/elt/roles.tf
+++ b/terraform/snowflake/modules/elt/roles.tf
@@ -227,6 +227,7 @@ resource "snowflake_grant_account_role" "streamlit_to_reporter" {
 
 # Grant CREATE STREAMLIT & CREATE STAGE privileges on future schemas in the database to the Streamlit access role
 resource "snowflake_grant_privileges_to_account_role" "streamlit_future_streamlit_privileges" {
+  provider          = snowflake.useradmin
   account_role_name = snowflake_account_role.streamlit_access_role.name
   privileges        = ["CREATE STREAMLIT", "CREATE STAGE"]
   on_schema {
@@ -236,6 +237,7 @@ resource "snowflake_grant_privileges_to_account_role" "streamlit_future_streamli
 
 # Grant CREATE STREAMLIT & CREATE STAGE privileges on the PUBLIC schema in the database to the Streamlit access role
 resource "snowflake_grant_privileges_to_account_role" "streamlit_public_streamlit_privileges" {
+  provider          = snowflake.useradmin
   account_role_name = snowflake_account_role.streamlit_access_role.name
   privileges        = ["CREATE STREAMLIT", "CREATE STAGE"]
   on_schema {


### PR DESCRIPTION
I encountered issue while applying the steamlit terraform changes - The error is shown below.

Looks like granting CREATE STREAMLIT privilege is not valid for databases. It's an account-level privilege as far as I remember.

So granting the CREATE STREAMLIT privilege at the account level instead of on a specific database.

Also there were some naming issue (_PRD_PRD_ instead of _PRD), that I could not catch previously because of oversight. Now fixed them.

Can you please review the changes and share your feedback ? Also included the latest plan - 

│ Error: An error occurred when granting privileges to account role
│ 
│   with module.elt.snowflake_grant_privileges_to_account_role.streamlit_privileges["analytics"],
│   on ../../modules/elt/roles.tf line 236, in resource "snowflake_grant_privileges_to_account_role" "streamlit_privileges":
│  236: resource "snowflake_grant_privileges_to_account_role" "streamlit_privileges" {
│ 
│ Id: "ANALYTICS_PRD_PRD_STREAMLIT"|false|false|CREATE STREAMLIT,CREATE STAGE|OnAccountObject|DATABASE|"ANALYTICS_PRD"
│ Account role name: {ANALYTICS_PRD_PRD_STREAMLIT}
│ Error: 003008 (42601): SQL compilation error:
│ Invalid object type 'DATABASE' for privilege 'CREATE STREAMLIT'.

**Latest Plan**

Terraform will perform the following actions:

  module.elt.snowflake_account_role.streamlit_analytics will be updated in-place
  ~ resource "snowflake_account_role" "streamlit_analytics" {
      ~ fully_qualified_name = "\"ANALYTICS_PRD_PRD_STREAMLIT\"" -> (known after apply)
        id                   = "ANALYTICS_PRD_PRD_STREAMLIT"
      ~ name                 = "ANALYTICS_PRD_PRD_STREAMLIT" -> "ANALYTICS_PRD_STREAMLIT"
      ~ show_output          = [
          - {
              - assigned_to_users = 0
              - comment           = "Permissions to create Streamlit applications and stages in the ANALYTICS_PRD database for the PRD environment."
              - created_on        = "2025-05-05 14:59:52.262 -0700 PDT"
              - granted_roles     = 0
              - granted_to_roles  = 1
              - is_current        = false
              - is_default        = false
              - is_inherited      = true
              - name              = "ANALYTICS_PRD_PRD_STREAMLIT"
              - owner             = "USERADMIN"
            },
        ] -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  module.elt.snowflake_grant_account_role.streamlit_analytics_to_reporter must be replaced
-/+ resource "snowflake_grant_account_role" "streamlit_analytics_to_reporter" {
      ~ id               = "\"ANALYTICS_PRD_PRD_STREAMLIT\"|ROLE|\"REPORTER_PRD\"" -> (known after apply)
      ~ role_name        = "ANALYTICS_PRD_PRD_STREAMLIT" -> "ANALYTICS_PRD_STREAMLIT" # forces replacement
        # (1 unchanged attribute hidden)
    }

   module.elt.snowflake_grant_privileges_to_account_role.streamlit_account_privileges will be created
  + resource "snowflake_grant_privileges_to_account_role" "streamlit_account_privileges" {
      + account_role_name = "ANALYTICS_PRD_STREAMLIT"
      + all_privileges    = false
      + always_apply      = false
      + id                = (known after apply)
      + on_account        = true
      + privileges        = [
          + "CREATE STREAMLIT",
        ]
      + with_grant_option = false
    }

  module.elt.snowflake_grant_privileges_to_account_role.streamlit_database_privileges will be created
  + resource "snowflake_grant_privileges_to_account_role" "streamlit_database_privileges" {
      + account_role_name = "ANALYTICS_PRD_STREAMLIT"
      + all_privileges    = false
      + always_apply      = false
      + id                = (known after apply)
      + on_account        = false
      + privileges        = [
          + "CREATE STAGE",
        ]
      + with_grant_option = false

      + on_account_object {
          + object_name = "ANALYTICS_PRD"
          + object_type = "DATABASE"
        }
    }

Plan: 3 to add, 1 to change, 1 to destroy.


