### PR TITLE
Set up networking for RDS to talk to other services

### DIFF
--- a/terraform/aws/environments/dev/.terraform.lock.hcl
+++ b/terraform/aws/environments/dev/.terraform.lock.hcl
@@ -24,6 +24,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/dns" {
+  version     = "3.5.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:l+PFNwnIKdM/Zjwn10RJ4yuj6xNoyL9efmsIRKc40k0=",
+    "zh:1b13839d263eedae417d4252191c586eb710e65dfeab65702d65fe3be4a271a4",
+    "zh:370a2a2e2823f137268cfed745f050b7bfd9eeb95783699b7ec3cf92bdf5889a",
+    "zh:4b32c1dc7cb0d47b605ac3f0a131e692e113ab3e160c4eb4a4575b9b746173fd",
+    "zh:6be64d175df8b09a8c4b36d2572d312781945feb1bc55782bf66bbaef5da76c3",
+    "zh:74b623bfa0ac8619f46de38c8ff2d9173691de93813d490bf633f06c6448cb1f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7cb7ceca39f716cc182eb74366217f2512d16c9682be816d9ae3764abbd5047b",
+    "zh:9af02e8e010269866b3501e3a03b5a611f59b17f546737deea4dee2e6eb48cd9",
+    "zh:d3d7bc737f9c9a4325b32486cb107d79b147c256a0e94593d82cfeef4c3ecaf2",
+    "zh:d542e7940374d1929d01b98720e2e69cead51304d9ffb1f3c1678326a79ede5f",
+    "zh:dfddb2e67012f4f0d91ba92ad156b30be88ab02f558798878d61035422b2f82e",
+    "zh:e5b5c16ffafc81671a0ca608a1765db68e949678948c987ebbde986d039e7c73",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.4.3"
   constraints = "3.4.3"

--- a/terraform/aws/environments/dev/main.tf
+++ b/terraform/aws/environments/dev/main.tf
@@ -56,6 +56,14 @@ module "infra" {
 
   # RDS SQL Server configuration
   enable_rds = true
+  bastion_authorized_keys = [
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCfK0wv8JVqrD9Y3VabRAOgqdIj9nZ1hqzmaiJNCW8Tfy0DRM6U6AomsPX25DaZm+TIwpMj7ymasaZ7G+dvEKeisCaKwMDqpZrv4S8PplpcV4fCbmtT7Q5CNHdhspkjyOf7Ee/rYNowicDUsDBxYTDNuucXJKwCgu7hMR43IPfYifhq9JqOrHtSZ1smQ3+8Hec0TybtztgJ5BC7xKYpphUodwNwPTK8gF6p5Dyroe+WkzyIHgmOy2d/wY7D/K/FOV2YinxIvRoo2L0DHExNnAPBzGFYfE4ZfNusbLPulvMHByNalCAwN14qJEZ88MY7COmOxzpFGE/aCJPIG/wAzvC1EE76GEGARjWgasI7ISopRHgLVajsEjHpH/gVrPckET6DGd+6J4amrbvsXaF1/+5NcZrW8CocMaMIgjrtweBbVUU8GrsF3WtL5SnGmr4d54e9EsnuagRVFHGA3ij6ie3U84T8fatqOQ6gOBHW+a6kxvgL4jQ+jiB0e8DjZD43sLWNeNofkvEx38ahqkYz136Q5H8yf0YGfr7xCCgZkrh0zZb9GBlakEHqiJIIRde33ab3LIQPkn+C0VDQFRZ6n2sCwN/G6qt+BVfHwUzGZo4JHTGDyDqqBBdGAipcAFwLZgnkNqfSaymO+V2SZEyBJ1i/ME4SHiB7wV+Cw4D14IwqfQ== fivetran user key"
+  ]
+  bastion_allowed_ssh_cidrs = [
+    # Fivetran GCP us-east-4 (default processing region)
+    "35.234.176.144/29",
+  ]
+
 }
 
 output "infra" {

--- a/terraform/aws/environments/dev/main.tf
+++ b/terraform/aws/environments/dev/main.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/random"
       version = "3.4.3"
     }
+    dns = {
+      source  = "hashicorp/dns"
+      version = "~> 3.0"
+    }
   }
 
   backend "s3" {
@@ -62,6 +66,9 @@ module "infra" {
   bastion_allowed_ssh_cidrs = [
     # Fivetran GCP us-east-4 (default processing region)
     "35.234.176.144/29",
+  ]
+  privatelink_allowed_principals = [
+    "arn:aws:iam::834469178297:root",  # Fivetran
   ]
 
 }

--- a/terraform/aws/environments/dev/main.tf
+++ b/terraform/aws/environments/dev/main.tf
@@ -68,6 +68,7 @@ module "infra" {
     "35.234.176.144/29",
   ]
   privatelink_allowed_principals = [
+    "arn:aws:iam::024848475617:root",  # Snowflake
     "arn:aws:iam::834469178297:root",  # Fivetran
   ]
 

--- a/terraform/aws/modules/infra/bastion.tf
+++ b/terraform/aws/modules/infra/bastion.tf
@@ -1,0 +1,107 @@
+##################################
+#         Bastion Host           #
+##################################
+
+data "aws_ami" "bastion" {
+  count       = var.enable_rds ? 1 : 0
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+}
+
+resource "aws_eip" "bastion" {
+  count    = var.enable_rds ? 1 : 0
+  domain   = "vpc"
+  instance = aws_instance.bastion[0].id
+
+  tags = {
+    Name = "${local.prefix}-bastion"
+  }
+}
+
+resource "aws_security_group" "bastion" {
+  count       = var.enable_rds ? 1 : 0
+  name        = "${local.prefix}-bastion-sg"
+  description = "Bastion host for RDS SSH tunnel access"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "SSH from allowed CIDRs"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.bastion_allowed_ssh_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.prefix}-bastion-sg"
+  }
+}
+
+resource "aws_iam_role" "bastion" {
+  count = var.enable_rds ? 1 : 0
+  name  = "${local.prefix}-bastion-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "bastion_ssm" {
+  count      = var.enable_rds ? 1 : 0
+  role       = aws_iam_role.bastion[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "bastion" {
+  count = var.enable_rds ? 1 : 0
+  name  = "${local.prefix}-bastion-profile"
+  role  = aws_iam_role.bastion[0].name
+}
+
+resource "aws_instance" "bastion" {
+  count         = var.enable_rds ? 1 : 0
+  ami           = data.aws_ami.bastion[0].id
+  instance_type = "t3.micro"
+  subnet_id     = aws_subnet.public[0].id
+
+  vpc_security_group_ids = [aws_security_group.bastion[0].id]
+  iam_instance_profile   = aws_iam_instance_profile.bastion[0].name
+
+  # We launch the instance with the list of known public keys.
+  # If that list changes, we force recration of the instance.
+  # A little heavy-handed, but favors configuration over code,
+  # and the IP stays the same.
+  user_data = <<-EOF
+    #!/bin/bash
+    %{ for key in var.bastion_authorized_keys ~}
+    echo "${key}" >> /home/ec2-user/.ssh/authorized_keys
+    %{ endfor ~}
+  EOF
+
+  user_data_replace_on_change = true
+
+  metadata_options {
+    http_tokens = "required" # IMDSv2
+  }
+
+  tags = {
+    Name = "${local.prefix}-bastion"
+  }
+}

--- a/terraform/aws/modules/infra/main.tf
+++ b/terraform/aws/modules/infra/main.tf
@@ -17,6 +17,10 @@ terraform {
       source  = "hashicorp/random"
       version = "3.4.3"
     }
+    dns = {
+      source  = "hashicorp/dns"
+      version = "~> 3.0"
+    }
   }
   required_version = ">= 1.0"
 }

--- a/terraform/aws/modules/infra/network.tf
+++ b/terraform/aws/modules/infra/network.tf
@@ -69,6 +69,14 @@ resource "aws_security_group" "rds_sqlserver" {
     security_groups = [aws_security_group.mwaa.id]
   }
 
+  ingress {
+    description     = "SQL Server access from bastion"
+    from_port       = 1433
+    to_port         = 1433
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion[0].id]
+  }
+
   tags = {
     Name = "${local.prefix}-rds-sqlserver-sg"
   }

--- a/terraform/aws/modules/infra/network.tf
+++ b/terraform/aws/modules/infra/network.tf
@@ -77,6 +77,14 @@ resource "aws_security_group" "rds_sqlserver" {
     security_groups = [aws_security_group.bastion[0].id]
   }
 
+  ingress {
+    description     = "SQL Server access from PrivateLink NLB"
+    from_port       = 1433
+    to_port         = 1433
+    protocol        = "tcp"
+    security_groups = [aws_security_group.privatelink_nlb[0].id]
+  }
+
   tags = {
     Name = "${local.prefix}-rds-sqlserver-sg"
   }

--- a/terraform/aws/modules/infra/outputs.tf
+++ b/terraform/aws/modules/infra/outputs.tf
@@ -21,5 +21,7 @@ output "state" {
     } : null
     bastion_public_ip   = var.enable_rds ? aws_eip.bastion[0].public_ip : null
     bastion_instance_id = var.enable_rds ? aws_instance.bastion[0].id : null
+    privatelink_endpoint_service_name = var.enable_rds ? aws_vpc_endpoint_service.rds[0].service_name : null
+    privatelink_nlb_dns_name          = var.enable_rds ? aws_lb.privatelink[0].dns_name : null
   }
 }

--- a/terraform/aws/modules/infra/outputs.tf
+++ b/terraform/aws/modules/infra/outputs.tf
@@ -19,5 +19,7 @@ output "state" {
       secret_arn    = aws_db_instance.sqlserver[0].master_user_secret[0].secret_arn
       secret_status = aws_db_instance.sqlserver[0].master_user_secret[0].secret_status
     } : null
+    bastion_public_ip   = var.enable_rds ? aws_eip.bastion[0].public_ip : null
+    bastion_instance_id = var.enable_rds ? aws_instance.bastion[0].id : null
   }
 }

--- a/terraform/aws/modules/infra/privatelink.tf
+++ b/terraform/aws/modules/infra/privatelink.tf
@@ -1,0 +1,108 @@
+##################################
+#          PrivateLink           #
+##################################
+
+# Resolve RDS endpoint to IP at apply time.
+# This is a short term resolution: IP can change after maintenance/failover.
+# If that happens, re-run terraform apply to re-register the new IP with the NLB target group.
+# AWS has a couple of possible ways to make this more robust:
+#
+#   1. Use RDS proxy for a more stable IP
+#   2. Set up a lambda to auto-refresh the target group for the NLB.
+#
+# Both of these increase the complexity of this POC, so keeping it simple for now,
+# knowing that this is a more fragile setup.
+data "dns_a_record_set" "rds" {
+  count = var.enable_rds ? 1 : 0
+  host  = aws_db_instance.sqlserver[0].address
+}
+
+resource "aws_security_group" "privatelink_nlb" {
+  count       = var.enable_rds ? 1 : 0
+  name        = "${local.prefix}-privatelink-nlb-sg"
+  description = "PrivateLink NLB for RDS SQL Server"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "From PrivateLink endpoints over 1433"
+    from_port   = 1433
+    to_port     = 1433
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Forward to resources in the private subnet (primarily RDS SQL Server)"
+    from_port   = 1433
+    to_port     = 1433
+    protocol    = "tcp"
+    cidr_blocks = aws_subnet.private[*].cidr_block
+  }
+
+  tags = {
+    Name = "${local.prefix}-privatelink-nlb-sg"
+  }
+}
+
+resource "aws_lb" "privatelink" {
+  count              = var.enable_rds ? 1 : 0
+  name               = "${local.prefix}-privatelink-nlb"
+  internal           = true
+  load_balancer_type = "network"
+  subnets            = aws_subnet.private[*].id
+  security_groups    = [aws_security_group.privatelink_nlb[0].id]
+
+  tags = {
+    Name = "${local.prefix}-privatelink-nlb"
+  }
+}
+
+resource "aws_lb_target_group" "rds" {
+  count       = var.enable_rds ? 1 : 0
+  name        = "${local.prefix}-rds-tg"
+  port        = 1433
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.this.id
+
+  health_check {
+    protocol = "TCP"
+    port     = 1433
+  }
+}
+
+resource "aws_lb_target_group_attachment" "rds" {
+  count            = var.enable_rds ? 1 : 0
+  target_group_arn = aws_lb_target_group.rds[0].arn
+  target_id        = data.dns_a_record_set.rds[0].addrs[0]
+  port             = 1433
+}
+
+resource "aws_lb_listener" "rds" {
+  count             = var.enable_rds ? 1 : 0
+  load_balancer_arn = aws_lb.privatelink[0].arn
+  port              = 1433
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.rds[0].arn
+  }
+}
+
+resource "aws_vpc_endpoint_service" "rds" {
+  count                      = var.enable_rds ? 1 : 0
+  network_load_balancer_arns = [aws_lb.privatelink[0].arn]
+  acceptance_required        = true
+
+  tags = {
+    Name = "${local.prefix}-rds-endpoint-service"
+  }
+}
+
+resource "aws_vpc_endpoint_service_allowed_principal" "consumers" {
+  for_each = var.enable_rds ? toset(var.privatelink_allowed_principals) : toset([])
+
+  vpc_endpoint_service_id = aws_vpc_endpoint_service.rds[0].id
+  principal_arn           = each.value
+}

--- a/terraform/aws/modules/infra/variables.tf
+++ b/terraform/aws/modules/infra/variables.tf
@@ -34,6 +34,18 @@ variable "enable_rds" {
   default     = false
 }
 
+variable "bastion_allowed_ssh_cidrs" {
+  description = "CIDR blocks allowed to SSH to the bastion (e.g. Fivetran IP ranges, office IPs)"
+  type        = list(string)
+  default     = []
+}
+
+variable "bastion_authorized_keys" {
+  description = "SSH public keys authorized to access the bastion (one per external system or developer)"
+  type        = list(string)
+  default     = []
+}
+
 locals {
   prefix = "${var.owner}-${var.project}-${var.environment}"
 }

--- a/terraform/aws/modules/infra/variables.tf
+++ b/terraform/aws/modules/infra/variables.tf
@@ -46,6 +46,12 @@ variable "bastion_authorized_keys" {
   default     = []
 }
 
+variable "privatelink_allowed_principals" {
+  description = "AWS principal ARNs allowed to connect via PrivateLink (e.g. Fivetran, Snowflake account ARNs in the form arn:aws:iam::<account-id>:root)"
+  type        = list(string)
+  default     = []
+}
+
 locals {
   prefix = "${var.owner}-${var.project}-${var.environment}"
 }


### PR DESCRIPTION
In #587 we set up a couple of SQL server instances, but the only thing that could actually talk to them was our Airflow instance. This allows for more services to actually talk to our AWS RDS instance. There are four ways that this allows for incoming connections:

1. Connecting over SSH via a bastion host from a known set of allow-listed IPs. This is what external integration tools would use (like Fivetran without privatelink). At least, tools that support SSH tunnels would use this.
1. Connecting over AWS SSM using IAM, using the same bastion host. This is what individual developers would use. I tried to use SSH keys for devs as well, but I wasn't able to make that play nicely with Jamf Trust. The story here might change in the future, but for now, the following allows devs to connect using SSM:
    * Open a tunnel in one terminal window using SSM with the following:
        ```bash
        aws ssm start-session --target <instance-id> \
        --document-name AWS-StartPortForwardingSessionToRemoteHost \
        --parameters '{"host":["<rds-hostname>"],"portNumber":["1433"],"localPortNumber":["1433"]}'
        ```
    * Log into the RDS in another terminal window with:
        ```bash
        sqlcmd -S localhost,1433 -U <username> -P '<password>'
        ```
1. Connecting Fivetran via PrivateLink. The `privatelink.tf` configuration sets up a network load balancer as well as a VPC endpoint service for external services to use. We then add Fivetran's AWS principal to the allowed consumers of that service. I roughly followed the instructions [here](https://fivetran.com/docs/destinations/connection-options/aws-private-link). The basic flow was:
    * Deploy the configuration, including adding Fivetran's (public) AWS account as an allowed consumer
    * Within Fivetran, create a new destination with the processing region in AWS us-west-2. Our existing destinations used the default GCP region. Normally that's fine, but won't work for AWS privatelink, since we need to connect the two accounts.
    * Within Fivetran, start the new RDS connector, following its new "Self Service Privatelink" flow. Here I give it the endpoint service, which allows it to request the connection. The connector setup has to pause while the request completes.
    * In the AWS console, approve the connection request that Fivetran makes. The whole process took ~30 minutes.
    * Complete the connection in the Fivetran dashboard as usual.
1. Connecting Snowflake via PrivateLink. This uses the exact same AWS infrastructure as the Fivetran connection, though the flow for setting up the connection on the Snowflake side is a little different. I used the docs [here](https://docs.snowflake.com/en/user-guide/private-manage-endpoints-aws) as well as the Snowflake engineering blog post [here](https://medium.com/snowflake/connecting-to-amazon-rds-using-private-connectivity-from-snowflake-c2b538d623ed). The flow was:
    * Use the same configuration as the Fivetran one above, but include the Snowflake account principal in the allowed consumers list.
    * Within Snowflake, create a new privatelink endpoint using $SYSTEM$PROVISION_PRIVATELINK_ENDPOINT
    * Within Snowflake, create network rules and external access integrations allowing access to the privatelink endpoint from, e.g., UDFs.
    * Test the connection using a UDF. I'll copy the worksheet code I executed in a separate comment

Here is a diagram of the architecture as of now:

<img width="2921" height="1808" alt="AWS RDS Connection - Page 1" src="https://github.com/user-attachments/assets/cf3f45ad-685e-4480-b73b-d9cb56988bce" />


Fixes #595 
Fixes #593 
Fixes #591 